### PR TITLE
refactor: normalizar naming snake_case (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,161 @@
 <img src="/assets/icon-lebre.png" alt="Lebre Icon" width="100px" align="right">
 
+# Lebre
 
-# Lebre populator
-A Database Populator is a tool which helps you to populate your projects' database tables with randomly generated content. With this tool you no longer need to write queries or to compile forms by yourself wasting a lot of time before to start to work on your applications.
+A Database Populator — generates random data to fill your project's database tables. No more writing queries or filling forms manually before you can start working on your application.
 
-#### Why Lebre?
+## Installation
 
-Lebres (Hares in english) are animals that usually represent fertility, they are related to several folk manifestations, therefore, there is nothing more fair to populate your database than our Lebre.
+```bash
+git clone https://github.com/luizfpq/lebre.git
+cd lebre
+pip install -e .
+```
 
-# Docs
+After installation the `lebre` command is available globally.
 
- - [ENGLISH (en-us)](README-en-us.md)
- - [PORTUGUÊS (pt-br)](README-pt-br.md)
+For YAML table support install the optional dependency:
+
+```bash
+pip install -e ".[yaml]"
+```
+
+## Quick start
+
+```bash
+# Define a table
+lebre create-table --name tbl_users \
+  --fields "id,cpf,nome,email,telefone" \
+  --types "Serial,CPF,FullName,Email,Phone" \
+  --records 100
+
+# Generate SQL
+lebre populate --format sql
+
+# Or print directly to stdout (pipe to psql, mysql, etc.)
+lebre populate --stdout --format sql | psql mydb
+
+# Generate CSV or JSON
+lebre populate --format csv
+lebre populate --format json --stdout
+```
+
+## CLI reference
+
+```
+lebre create-table   Create a table definition file
+lebre populate       Generate data from existing table definitions
+lebre list-types     Show all available data types
+```
+
+### create-table
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Table name (required) |
+| `--fields` | Comma-separated field names (required) |
+| `--types` | Comma-separated data types (required) |
+| `--records` | Number of records to generate (required) |
+| `--tables-dir` | Directory to save definitions (default: `tables`) |
+| `--table-format` | Output format: `json`, `yaml`, `toml` (default: `json`) |
+
+### populate
+
+| Flag | Description |
+|------|-------------|
+| `--tables-dir` | Directory with table definitions (default: `tables`) |
+| `--output-dir` | Output directory (default: `results`) |
+| `--format` | Output format: `sql`, `csv`, `json` (default: `sql`) |
+| `--dialect` | SQL quoting style: `postgresql`, `mysql`, `sqlite` (default: `postgresql`) |
+| `--stdout` | Print to terminal instead of writing a file |
+
+## Available data types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `Serial` | Auto-increment integer | `Serial` or `Serial:100` |
+| `Integer:min:max` | Random integer in range | `Integer:0:10` |
+| `FullName` | Full name from BR datasource | `FullName` |
+| `FirstName` | First name (derived from FullName) | `FirstName` |
+| `LastName` | Last name (derived from FullName) | `LastName` |
+| `UserName` | Username from full name | `UserName` or `UserName:Num` |
+| `Email` | Email from full name | `Email` |
+| `InitName` | First character of previous name field | `InitName` |
+| `CPF` | Valid Brazilian CPF | `CPF` |
+| `CNPJ` | Valid Brazilian CNPJ | `CNPJ` |
+| `Phone` | Brazilian phone number | `Phone`, `Phone:fixo`, `Phone:11` |
+| `CEP` | Brazilian postal code | `CEP` or `CEP:SP` |
+| `Sex` | Random sex from datasource | `Sex` |
+| `Address` | Street address | `Address` or `Address:Num` |
+| `City` | City name | `City` or `City:SP` |
+| `StateProvince` | State/province | `StateProvince` or `StateProvince:Find` |
+| `Date` | Random date | `Date` or `Date:01/01/1990:31/12/2020` |
+| `DateTime` | Random date + time | `DateTime` |
+| `UUID` | UUID v4 | `UUID` |
+| `Boolean` | TRUE/FALSE or 1/0 | `Boolean` or `Boolean:int` |
+| `Varchar:N` | Random string of length N | `Varchar:10` |
+| `Default:value` | Fixed value for all rows | `Default:'active'` |
+
+## Table definition formats
+
+Tables can be defined in JSON, YAML or TOML:
+
+```json
+[{
+    "TableName": "tbl_users",
+    "FieldList": "id,nome,email",
+    "DataType": "Serial,FullName,Email",
+    "RecordsToGenerate": 50
+}]
+```
+
+```yaml
+TableName: tbl_users
+FieldList: id,nome,email
+DataType: Serial,FullName,Email
+RecordsToGenerate: 50
+```
+
+```toml
+[table]
+TableName = "tbl_users"
+FieldList = "id,nome,email"
+DataType = "Serial,FullName,Email"
+RecordsToGenerate = 50
+```
+
+## SQL dialects
+
+```bash
+lebre populate --format sql --dialect postgresql   # "table" ("col")
+lebre populate --format sql --dialect mysql        # `table` (`col`)
+lebre populate --format sql --dialect sqlite       # table (col)
+```
+
+## Pipeline examples
+
+```bash
+# Seed a PostgreSQL database
+lebre populate --stdout --dialect postgresql | psql -d myapp
+
+# Seed MySQL
+lebre populate --stdout --dialect mysql | mysql myapp
+
+# Generate CSV for data analysis
+lebre populate --format csv --stdout > dataset.csv
+
+# Generate JSON for API mocking
+lebre populate --format json --stdout | jq '.tbl_users[:5]'
+```
+
+## Why Lebre?
+
+Lebres (Hares) are animals that represent fertility in several folk traditions. There is nothing more fitting to populate your database than a Lebre.
+
+## License
+
+GPL v3
+
+---
 
 <a href="https://icons8.com/icon/95136/owl">Lebre icon by Icons8</a>

--- a/cli.py
+++ b/cli.py
@@ -183,42 +183,42 @@ def cmd_populate(args):
 
 
 def _generate_values(table_dict):
-    """Gera ValueDict para uma definição de tabela (lógica extraída do table_populator)."""
+    """Gera value_dict para uma definição de tabela (lógica extraída do table_populator)."""
     records = get_count_records_to_generate(table_dict)
     field_count = get_count_field_list(table_dict)
-    DataList = [item.strip() for item in table_dict[0]['DataType'].split(",")]
+    data_list = [item.strip() for item in table_dict[0]['DataType'].split(",")]
 
-    ValueDict = []
-    FullNameValues = []
+    value_dict = []
+    fullname_values = []
 
     # Gera FullName primeiro (necessário para FirstName, LastName, UserName, Email)
-    has_fullname_field = any('FullName' in item for item in DataList)
-    needs_fullname = any(k in item for item in DataList for k in ['FirstName', 'LastName', 'UserName', 'Email'])
+    has_fullname_field = any('FullName' in item for item in data_list)
+    needs_fullname = any(k in item for item in data_list for k in ['FirstName', 'LastName', 'UserName', 'Email'])
 
     if has_fullname_field or needs_fullname:
-        for item in DataList:
+        for item in data_list:
             if 'FullName' in item:
-                FullNameValues = DataLoad(records, item.strip(), ValueDict)
+                fullname_values = DataLoad(records, item.strip(), value_dict)
                 break
         else:
-            FullNameValues = DataLoad(records, 'FullName', ValueDict)
+            fullname_values = DataLoad(records, 'FullName', value_dict)
 
     # Gera os outros campos
-    for item in DataList:
+    for item in data_list:
         if 'FullName' not in item:
             if any(k in item for k in ['FirstName', 'LastName', 'UserName', 'Email']):
-                values = DataLoad(records, item.strip(), [FullNameValues])
+                values = DataLoad(records, item.strip(), [fullname_values])
             else:
-                values = DataLoad(records, item.strip(), ValueDict)
-            ValueDict.append(values)
+                values = DataLoad(records, item.strip(), value_dict)
+            value_dict.append(values)
 
     # Insere FullName na posição correta se estava no DataType
-    for i, item in enumerate(DataList):
+    for i, item in enumerate(data_list):
         if 'FullName' in item:
-            ValueDict.insert(i, [f"{name}" for name in FullNameValues])
+            value_dict.insert(i, [f"{name}" for name in fullname_values])
             break
 
-    return ValueDict, records, field_count
+    return value_dict, records, field_count
 
 
 def _quote_identifier(name, dialect):
@@ -239,7 +239,7 @@ def _populate_sql(table_files, output_file, dialect='postgresql'):
             table_dict = _load_table_file(tf)
 
             table_name = get_table_name(table_dict)
-            ValueDict, records, field_count = _generate_values(table_dict)
+            value_dict, records, field_count = _generate_values(table_dict)
 
             # Quoting do nome da tabela e campos
             quoted_table = _quote_identifier(table_name, dialect)
@@ -249,7 +249,7 @@ def _populate_sql(table_files, output_file, dialect='postgresql'):
             fh.write(f'INSERT INTO\n\t{quoted_table} ({quoted_fields})\nVALUES\n')
 
             for i in range(records):
-                values = ', '.join(str(ValueDict[col][i]) for col in range(field_count))
+                values = ', '.join(str(value_dict[col][i]) for col in range(field_count))
                 separator = ';' if i == records - 1 else ','
                 fh.write(f"\t({values}){separator}\n")
     finally:
@@ -265,7 +265,7 @@ def _populate_csv(table_files, output_file):
             table_dict = _load_table_file(tf)
 
             fields = [field.strip() for field in table_dict[0]['FieldList'].split(',')]
-            ValueDict, records, field_count = _generate_values(table_dict)
+            value_dict, records, field_count = _generate_values(table_dict)
 
             # Header
             fh.write(','.join(fields) + '\n')
@@ -274,7 +274,7 @@ def _populate_csv(table_files, output_file):
             for i in range(records):
                 row = []
                 for col in range(field_count):
-                    val = str(ValueDict[col][i])
+                    val = str(value_dict[col][i])
                     # Remove aspas SQL simples para CSV
                     if val.startswith("'") and val.endswith("'"):
                         val = val[1:-1]
@@ -296,13 +296,13 @@ def _populate_json(table_files, output_file):
 
         table_name = get_table_name(table_dict)
         fields = [field.strip() for field in table_dict[0]['FieldList'].split(',')]
-        ValueDict, records, field_count = _generate_values(table_dict)
+        value_dict, records, field_count = _generate_values(table_dict)
 
         rows = []
         for i in range(records):
             row = {}
             for col in range(field_count):
-                val = ValueDict[col][i]
+                val = value_dict[col][i]
                 # Remove aspas SQL simples para JSON
                 if isinstance(val, str) and val.startswith("'") and val.endswith("'"):
                     val = val[1:-1]

--- a/generators/DataLoader.py
+++ b/generators/DataLoader.py
@@ -7,123 +7,75 @@ __author__ = "Luiz F. P. Quirino"
 __copyright__ = "Copyleft 2020, Planet Earth"
 __credits__ = ["LuizQuirino"]
 __license__ = "GPL v3"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __maintainer__ = "LuizQuirino"
 __email__ = "luizfpq@gmail.com"
 __status__ = "Dev"
 
 
 import random
-''' TextTypes reponses for all nom numeric data'''
+
 from generators.TextTypes import *
-''' DateTime responses for all DateTime based data'''
 from generators.DateTime import *
-''' NumericTypes responses for all generic numeric data '''
 from generators.NumericTypes import *
 
-def DataLoad(recordsToGenerate, dType, ValueDict):
 
-    '''
-        TextTypes
-    '''
-    if 'FullName' in dType:
-        return FullName(recordsToGenerate, dType)
-    if 'FirstName' in dType:
-        return FirstName(recordsToGenerate, dType, ValueDict)
-    if 'LastName' in dType:
-        return LastName(recordsToGenerate, dType, ValueDict)
-    if 'Email' in dType:
-        return Email(recordsToGenerate, dType, ValueDict)
-    ''' 
-        USO: 
-        Sempre que usar um campo inicial, ao criar o campo para os inserts, 
-        sempre colocar o campo da inicial logo a seguir do campo nome, 
-        pode-se usar a seguir de um FirstName, LastName, FullName, ou qualquer 
-        string que se queira obter a inicial
-    '''
-    if dType == 'InitName':
-        return  InitName(recordsToGenerate, dType, ValueDict)
-    ''' 
-        USO: 
-        Caso queira uma uma concatenação dos 3 primeiros e 3 ultimos carateres da string
-        Sempre que usar um campo inicial, ao criar o campo para os inserts, 
-        sempre colocar o campo da inicial logo a seguir do campo nome, 
-        pode-se usar a seguir de um FirstName, LastName, FullName, ou qualquer 
-        string que se queira obter a inicial
-    '''
-    if dType == 'UserName':
-        return UserName(recordsToGenerate, dType, ValueDict)
-    '''
-        USO:
-        Caso queira alterar o tipo de dado retornado, alterar o dicionario de sexos em 
-        datasources/Sex.txt
-    '''
-    if dType == 'Sex':
-        return  Sex(recordsToGenerate, dType)
-    if dType == 'CPF':
-        return CPF(recordsToGenerate, dType)
-    '''
-        USO: 
-            Varchar:size
-    '''
-    if "Varchar" in dType:
-        return Varchar(recordsToGenerate, dType)
-    ''' 
-        USO: 
-            caso queira definir um numero aleatório ao endereço
-                Address:Num
-            caso queira apenas um logradouro aleatório
-                Address
-    '''
-    if "Address" in dType:
-        return Address(recordsToGenerate, dType)
-    if "City" in dType:
-        return City(recordsToGenerate, dType, ValueDict)   
-    if "StateProvince" in dType:
-        return StateProvince(recordsToGenerate, dType, ValueDict)
+def DataLoad(records_to_generate, data_type, value_dict):
+    """
+    Dispatcher principal — roteia para o gerador correto conforme data_type.
+    Nomes de tipo usam PascalCase (API pública dos geradores).
+    """
 
-    '''
-        NumericTypes
-    '''
-    if 'Serial' in dType:
-        return Serial(recordsToGenerate, dType)
-    
-    if 'Integer' in dType:
-        return Integer(recordsToGenerate, dType)
+    # --- TextTypes ---
+    if 'FullName' in data_type:
+        return FullName(records_to_generate, data_type)
+    if 'FirstName' in data_type:
+        return FirstName(records_to_generate, data_type, value_dict)
+    if 'LastName' in data_type:
+        return LastName(records_to_generate, data_type, value_dict)
+    if 'Email' in data_type:
+        return Email(records_to_generate, data_type, value_dict)
+    if data_type == 'InitName':
+        return InitName(records_to_generate, data_type, value_dict)
+    if data_type == 'UserName' or data_type.startswith('UserName:'):
+        return UserName(records_to_generate, data_type, value_dict)
+    if data_type == 'Sex':
+        return Sex(records_to_generate, data_type)
+    if data_type == 'CPF':
+        return CPF(records_to_generate, data_type)
+    if "Varchar" in data_type:
+        return Varchar(records_to_generate, data_type)
+    if "Address" in data_type:
+        return Address(records_to_generate, data_type)
+    if "City" in data_type:
+        return City(records_to_generate, data_type, value_dict)
+    if "StateProvince" in data_type:
+        return StateProvince(records_to_generate, data_type, value_dict)
 
+    # --- NumericTypes ---
+    if 'Serial' in data_type:
+        return Serial(records_to_generate, data_type)
+    if 'Integer' in data_type:
+        return Integer(records_to_generate, data_type)
 
-    '''
-        DateTimeTypes
-    '''
-    if 'Date' in dType and 'DateTime' not in dType:
-        return Date(recordsToGenerate, dType)
-    if 'DateTime' in dType:
-        return DateTime(recordsToGenerate, dType)
-    '''
-        Set a Default data, wich returns itself, to set default values on fields
-        Example1
-        Default:'00235'
-        Return: '00235'
-        Example2
-        Default:00235
-        Return: 00235
-    '''
-    if "Default" in dType:
-        dataList = []
-        for i in range(recordsToGenerate):
-            dataList.append(dType.split(":")[1])
-        return dataList
+    # --- DateTimeTypes ---
+    if 'Date' in data_type and 'DateTime' not in data_type:
+        return Date(records_to_generate, data_type)
+    if 'DateTime' in data_type:
+        return DateTime(records_to_generate, data_type)
 
-    '''
-        Novos tipos v2.1
-    '''
-    if 'Phone' in dType:
-        return Phone(recordsToGenerate, dType)
-    if 'CNPJ' in dType:
-        return CNPJ(recordsToGenerate, dType)
-    if 'CEP' in dType:
-        return CEP(recordsToGenerate, dType)
-    if 'UUID' in dType:
-        return UUID(recordsToGenerate, dType)
-    if 'Boolean' in dType:
-        return Boolean(recordsToGenerate, dType)
+    # --- Default (retorna valor fixo) ---
+    if "Default" in data_type:
+        return [data_type.split(":")[1] for _ in range(records_to_generate)]
+
+    # --- Novos tipos v2.1 ---
+    if 'Phone' in data_type:
+        return Phone(records_to_generate, data_type)
+    if 'CNPJ' in data_type:
+        return CNPJ(records_to_generate, data_type)
+    if 'CEP' in data_type:
+        return CEP(records_to_generate, data_type)
+    if 'UUID' in data_type:
+        return UUID(records_to_generate, data_type)
+    if 'Boolean' in data_type:
+        return Boolean(records_to_generate, data_type)

--- a/generators/DateTime.py
+++ b/generators/DateTime.py
@@ -35,36 +35,36 @@ def str_time_prop(start, end, fmt, prop):
 
 
 def random_date_time(start, end, prop):
-    randDateTime = str_time_prop(start, end, '%d/%m/%Y %I:%M %p', prop)
-    return '\''+randDateTime+'\''
+    rand_datetime = str_time_prop(start, end, '%d/%m/%Y %I:%M %p', prop)
+    return '\''+rand_datetime+'\''
 
 def random_date(start, end, prop):
-    randDate = str_time_prop(start, end, '%d/%m/%Y', prop)
-    return '\''+randDate+'\''
+    rand_date = str_time_prop(start, end, '%d/%m/%Y', prop)
+    return '\''+rand_date+'\''
 
 
-def Date(recordsToGenerate, dType):
+def Date(records_to_generate, data_type):
     """
     Gera uma lista de datas aleatórias.
     USO:
         Date                        -> data entre 01/01/1970 e 01/01/2000
         Date:01/01/1990:31/12/2020  -> data no intervalo especificado
     """
-    if ":" in dType:
-        parts = dType.split(":")
+    if ":" in data_type:
+        parts = data_type.split(":")
         start = parts[1]
         end = parts[2]
     else:
         start = "1/1/1970"
         end = "1/1/2000"
 
-    dataList = []
-    for _ in range(recordsToGenerate):
-        dataList.append(random_date(start, end, random.random()))
-    return dataList
+    data_list = []
+    for _ in range(records_to_generate):
+        data_list.append(random_date(start, end, random.random()))
+    return data_list
 
 
-def DateTime(recordsToGenerate, dType):
+def DateTime(records_to_generate, data_type):
     """
     Gera uma lista de datas com hora aleatórias.
     USO:
@@ -74,7 +74,7 @@ def DateTime(recordsToGenerate, dType):
     start = "1/1/1970 12:00 AM"
     end = "1/1/2000 11:59 PM"
 
-    dataList = []
-    for _ in range(recordsToGenerate):
-        dataList.append(random_date_time(start, end, random.random()))
-    return dataList
+    data_list = []
+    for _ in range(records_to_generate):
+        data_list.append(random_date_time(start, end, random.random()))
+    return data_list

--- a/generators/Getters.py
+++ b/generators/Getters.py
@@ -1,36 +1,28 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 """
-    A Database Populator is a tool which helps you to populate your projects' database tables
-    with randomly generated content. With this tool you no longer need to write queries or to
-    compile forms by yourself wasting a lot of time before to start to work on your applications.
+    Funções auxiliares para extrair informações das definições de tabela.
 """
 __author__ = "Luiz F. P. Quirino"
 __copyright__ = "Copyleft 2020, Planet Earth"
 __credits__ = ["LuizQuirino"]
 __license__ = "GPL v3"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __maintainer__ = "LuizQuirino"
 __email__ = "luizfpq@gmail.com"
 __status__ = "Dev"
 
+
 def get_table_name(table_dict):
-    '''
-    Recupera o nome da tabela a ser manipulada
-    '''
-    tableName = table_dict[0]['TableName']
-    return tableName
+    """Recupera o nome da tabela a ser manipulada."""
+    return table_dict[0]['TableName']
+
 
 def get_count_records_to_generate(table_dict):
-    '''
-        Recupera a quantidade de inserções a gerar
-    '''
-    recordsToGenerate = table_dict[0]['RecordsToGenerate']
-    return recordsToGenerate
+    """Recupera a quantidade de inserções a gerar."""
+    return table_dict[0]['RecordsToGenerate']
+
 
 def get_count_field_list(table_dict):
-    '''
-    Conta os campos que foram passados no parametro FieldList
-    '''
-    num_fields = len(list(table_dict[0]['FieldList'].split(",")))
-    return num_fields
+    """Conta os campos que foram passados no parâmetro FieldList."""
+    return len(table_dict[0]['FieldList'].split(","))

--- a/generators/NumericTypes.py
+++ b/generators/NumericTypes.py
@@ -1,49 +1,37 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 """
-    Dataloader defines data types and load them all from datasource files
+    Geradores de tipos numéricos.
 """
 __author__ = "Luiz F. P. Quirino"
 __copyright__ = "Copyleft 2020, Planet Earth"
 __credits__ = ["LuizQuirino"]
 __license__ = "GPL v3"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __maintainer__ = "LuizQuirino"
 __email__ = "luizfpq@gmail.com"
 __status__ = "Dev"
 
 import random
 
-def Integer(recordsToGenerate, arg):
-    '''
-    Define o tipo inteiro
-        USO: 
-            Integer:min_value:max_value
-            ex: Integer:0:10
-    '''
-    dataList = []
-    for i in range(recordsToGenerate):
-        dataList.append(random.randint(int(arg.split(":")[1]), int(arg.split(":")[2])))
-    return dataList
 
-def Serial(recordsToGenerate, arg):
-    '''
-    Define o tipo serial, sendo um tipo inteiro, com comportamento semelhante ao autoincrimento,
-    bastante usado em chavez primárias ou indices de tabelas
-        USO: 
-        Caso queira definir um valor inicial
-            Serial:10
-        Caso queira iniciar do zero
-            Serial
-    '''
-    dataList = []
-    # atribui o valor inicial do serial(autoincremento)
-    if ":" in arg:
-        serial = int(arg.split(":")[1])
-    else:
-        serial = 0
+def Integer(records_to_generate, data_type):
+    """
+    Define o tipo inteiro.
+    USO: Integer:min_value:max_value (ex: Integer:0:10)
+    """
+    parts = data_type.split(":")
+    min_val = int(parts[1])
+    max_val = int(parts[2])
+    return [random.randint(min_val, max_val) for _ in range(records_to_generate)]
 
-    for i in range(recordsToGenerate):
-        dataList.append(serial)
-        serial = serial + 1
-    return dataList
+
+def Serial(records_to_generate, data_type):
+    """
+    Define o tipo serial (autoincremento).
+    USO:
+        Serial:10  -> inicia em 10
+        Serial     -> inicia em 0
+    """
+    start = int(data_type.split(":")[1]) if ":" in data_type else 0
+    return [start + i for i in range(records_to_generate)]

--- a/generators/TextTypes.py
+++ b/generators/TextTypes.py
@@ -50,12 +50,12 @@ def random_char(y):
     return '\''+randChar+'\''
 
 
-def CPF(recordsToGenerate, dType):
+def CPF(records_to_generate, data_type):
     '''
     Gera o cadastro de pessoas físicas, com um valor validável
     '''
-    dataList = []
-    for i in range(recordsToGenerate):
+    data_list = []
+    for i in range(records_to_generate):
         cpf = [random.randint(0, 9) for x in range(9)]                              
                                                                                     
         for _ in range(2):                                                          
@@ -63,131 +63,131 @@ def CPF(recordsToGenerate, dType):
                                                                                     
             cpf.append(11 - val if val > 1 else 0)                                  
 
-        dataList.append('%s%s%s.%s%s%s.%s%s%s-%s%s' % tuple(cpf))
-    return dataList
+        data_list.append('%s%s%s.%s%s%s.%s%s%s-%s%s' % tuple(cpf))
+    return data_list
 
-#def InitName(recordsToGenerate, dType, ValueDict):
-#    dataList = []
-#    for i in range(recordsToGenerate):
+#def InitName(records_to_generate, data_type, value_dict):
+#    data_list = []
+#    for i in range(records_to_generate):
 #        
-#    return dataList
+#    return data_list
 
-def FullName(recordsToGenerate, dType):
+def FullName(records_to_generate, data_type):
     """
     Gera uma lista de nomes completos a partir do arquivo FullNameBR.txt.
     """
-    dataList = []
+    data_list = []
     lines = _get_datasource('FullNameBR.txt')
-    for i in range(recordsToGenerate):
-        myline = random.choice(lines).strip()
-        dataList.append(f"'{myline}'")
-    return dataList
+    for i in range(records_to_generate):
+        line = random.choice(lines).strip()
+        data_list.append(f"'{line}'")
+    return data_list
 
-def FirstName(recordsToGenerate, dType, ValueDict):
+def FirstName(records_to_generate, data_type, value_dict):
     """
     Gera uma lista de primeiros nomes a partir da lista de nomes completos.
     """
-    dataList = []
-    for i in range(recordsToGenerate):
-        fullname = ValueDict[0][i]  # Assume que FullName é o primeiro no ValueDict
+    data_list = []
+    for i in range(records_to_generate):
+        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
         if not fullname:
             continue  # Ignore se fullname for None ou vazio
 
         firstname = fullname.split()[0].strip("'")
-        dataList.append(f"'{firstname}'")
-    return dataList
+        data_list.append(f"'{firstname}'")
+    return data_list
 
 
-def LastName(recordsToGenerate, dType, ValueDict):
+def LastName(records_to_generate, data_type, value_dict):
     """
     Gera uma lista de sobrenomes a partir da lista de nomes completos.
     """
-    dataList = []
-    for i in range(recordsToGenerate):
-        fullname = ValueDict[0][i]  # Assume que FullName é o primeiro no ValueDict
+    data_list = []
+    for i in range(records_to_generate):
+        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
         if not fullname:
             continue  # Ignore se fullname for None ou vazio
 
         lastname = fullname.split()[-1].strip("'")
-        dataList.append(f"'{lastname}'")
-    return dataList
+        data_list.append(f"'{lastname}'")
+    return data_list
 
 
-def UserName(recordsToGenerate, dType, ValueDict):
+def UserName(records_to_generate, data_type, value_dict):
     """
     Gera uma lista de nomes de usuário a partir da lista de nomes completos.
     """
-    dataList = []
-    for i in range(recordsToGenerate):
-        fullname = ValueDict[0][i]  # Assume que FullName é o primeiro no ValueDict
+    data_list = []
+    for i in range(records_to_generate):
+        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
         if not fullname:
             continue  # Ignore se fullname for None ou vazio
 
         fullname = fullname.strip("'")  # Remove aspas externas
         parts = fullname.split()
         username = (parts[0][0] + parts[-1]).lower()  # Primeiro caractere do primeiro nome + sobrenome
-        if ":" in dType:
-            if 'Num' in dType:
+        if ":" in data_type:
+            if 'Num' in data_type:
                 number = str(randint(0, 999999)).rjust(6, "0")
                 username = username + number
-        dataList.append(f"'{username}'")
-    return dataList
+        data_list.append(f"'{username}'")
+    return data_list
 
 
-def Email(recordsToGenerate, dType, ValueDict):
+def Email(records_to_generate, data_type, value_dict):
     """
     Gera uma lista de emails a partir da lista de nomes completos.
     """
-    dataList = []
-    for i in range(recordsToGenerate):
-        fullname = ValueDict[0][i]  # Assume que FullName é o primeiro no ValueDict
+    data_list = []
+    for i in range(records_to_generate):
+        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
         parts = fullname.strip("'").split()
         email = (parts[0] + '.' + parts[-1]).lower() + "@example.com"  # Primeiro nome + ponto + sobrenome + @example.com
-        dataList.append(f"'{email}'")
-    return dataList
+        data_list.append(f"'{email}'")
+    return data_list
 
 # TODO migrar listas para dicionarios
-def InitName(recordsToGenerate, dType, ValueDict):
-    dataList = []
-    for i in range(recordsToGenerate):
+def InitName(records_to_generate, data_type, value_dict):
+    data_list = []
+    for i in range(records_to_generate):
         # recebemos o primeiro caracter do ultimo nome usado na lista
-        myline = str(ValueDict[-1][i][1])
-        myline = myline.split(",")[0]
-        dataList.append('\''+myline+'\'')
-    return dataList
+        line = str(value_dict[-1][i][1])
+        line = line.split(",")[0]
+        data_list.append('\''+line+'\'')
+    return data_list
 
-def Sex(recordsToGenerate, dType):
-    dataList = []
+def Sex(records_to_generate, data_type):
+    data_list = []
     lines = _get_datasource('Sex.txt')
-    for i in range(recordsToGenerate):
-        myline = random.choice(lines)
-        dataList.append('\''+myline+'\'')
-    return dataList
+    for i in range(records_to_generate):
+        line = random.choice(lines)
+        data_list.append('\''+line+'\'')
+    return data_list
 
-def Address(recordsToGenerate, dType):
-    dataList = []
+def Address(records_to_generate, data_type):
+    data_list = []
     address_lines = _get_datasource('AddressTypeBR.txt')
     name_lines = _get_datasource('FullNameBR.txt')
 
-    for i in range(recordsToGenerate):
-        myline = random.choice(address_lines)
-        placeType = myline.split(",")[0]
+    for i in range(records_to_generate):
+        line = random.choice(address_lines)
+        place_type = line.split(",")[0]
 
         chosen_line = random.choice(name_lines)
         words = chosen_line.split()
         num_words_to_select = random.randint(1, 2)
         selected_words = random.sample(words, min(num_words_to_select, len(words)))
-        myline = placeType+' '+' '.join(selected_words)
+        line = place_type+' '+' '.join(selected_words)
         
-        if ":" in dType:
-            if 'Num' in dType:
+        if ":" in data_type:
+            if 'Num' in data_type:
                 number = str(randint(0, 999))
-                myline = myline + ', ' + number
+                line = line + ', ' + number
                 
-        dataList.append('\''+myline+'\'')
-    return dataList
+        data_list.append('\''+line+'\'')
+    return data_list
 
-def City(recordsToGenerate, dType, ValueDict):
+def City(records_to_generate, data_type, value_dict):
     ''' 
         USO: 
             caso queira definir uma cidade de estado específico
@@ -196,22 +196,22 @@ def City(recordsToGenerate, dType, ValueDict):
             caso queira apenas uma cidade aleatória
                 City
     '''
-    dataList = []
-    if ":" in dType:
-        lines = _search_in_datasource('CityBR.txt', str(dType.split(":")[1]))
+    data_list = []
+    if ":" in data_type:
+        lines = _search_in_datasource('CityBR.txt', str(data_type.split(":")[1]))
     else:
         lines = _get_datasource('CityBR.txt')
 
-    for i in range(recordsToGenerate):
-        myline = random.choice(lines)
-        if ":" in dType:
-            myline = myline.split(",")[2].replace("\n", "")
+    for i in range(records_to_generate):
+        line = random.choice(lines)
+        if ":" in data_type:
+            line = line.split(",")[2].replace("\n", "")
         else:
-            myline = myline.split(",")[2]
-        dataList.append('\''+myline+'\'')
-    return dataList
+            line = line.split(",")[2]
+        data_list.append('\''+line+'\'')
+    return data_list
 
-def StateProvince(recordsToGenerate, dType, ValueDict):
+def StateProvince(records_to_generate, data_type, value_dict):
     ''' 
         USO: 
             Caso queira apenas um estado aleatório
@@ -223,40 +223,40 @@ def StateProvince(recordsToGenerate, dType, ValueDict):
                 StateProvince:Find
             
             IMPORTANTE
-            NUNCA USE O FIND COM recordsToGenerate > 50
+            NUNCA USE O FIND COM records_to_generate > 50
             isso causa um estouro nos indices das listas usadas
             
     '''
-    dataList = []
+    data_list = []
 
-    # Pré-carrega linhas para modos que não dependem de ValueDict por registro
-    if ":" in dType and 'Find' not in dType:
-        lines = _search_in_datasource('CityBR.txt', str(dType.split(":")[1]))
-    elif ":" not in dType:
+    # Pré-carrega linhas para modos que não dependem de value_dict por registro
+    if ":" in data_type and 'Find' not in data_type:
+        lines = _search_in_datasource('CityBR.txt', str(data_type.split(":")[1]))
+    elif ":" not in data_type:
         lines = _get_datasource('StateProvinceBR.txt')
     else:
         lines = None  # modo Find — depende de cada registro
 
-    for i in range(recordsToGenerate):
-        if ":" in dType:
-            if 'Find' in dType:
-                matched = _search_in_datasource('CityBR.txt', str(ValueDict[-1][i].replace("'", '')))
-                myline = str(matched[0])
-                myline = myline.split(",")[0].replace("\n", "")
+    for i in range(records_to_generate):
+        if ":" in data_type:
+            if 'Find' in data_type:
+                matched = _search_in_datasource('CityBR.txt', str(value_dict[-1][i].replace("'", '')))
+                line = str(matched[0])
+                line = line.split(",")[0].replace("\n", "")
             else:
-                myline = random.choice(lines)
-                myline = myline.split(",")[0].replace("\n", "")
+                line = random.choice(lines)
+                line = line.split(",")[0].replace("\n", "")
         else:
-            myline = random.choice(lines)
-        dataList.append(str('\''+myline+'\''))
-    return dataList
+            line = random.choice(lines)
+        data_list.append(str('\''+line+'\''))
+    return data_list
 
-def Varchar(recordsToGenerate, dType):
+def Varchar(records_to_generate, data_type):
 
-    dataList = []
-    for i in range(recordsToGenerate):
-        dataList.append(random_char(int(dType.split(":")[1])))
-    return dataList
+    data_list = []
+    for i in range(records_to_generate):
+        data_list.append(random_char(int(data_type.split(":")[1])))
+    return data_list
 
 
 
@@ -267,7 +267,7 @@ def Varchar(recordsToGenerate, dType):
 import uuid as _uuid
 
 
-def Phone(recordsToGenerate, dType):
+def Phone(records_to_generate, data_type):
     """
     Gera números de telefone brasileiros.
     USO:
@@ -275,10 +275,10 @@ def Phone(recordsToGenerate, dType):
         Phone:fixo    -> fixo com DDD aleatório, formato (XX) XXXX-XXXX
         Phone:XX      -> celular com DDD específico (ex: Phone:11)
     """
-    dataList = []
-    for _ in range(recordsToGenerate):
-        if ":" in dType:
-            param = dType.split(":")[1]
+    data_list = []
+    for _ in range(records_to_generate):
+        if ":" in data_type:
+            param = data_type.split(":")[1]
             if param == 'fixo':
                 ddd = str(randint(11, 99))
                 number = f"({ddd}) {randint(2000,5999)}-{randint(1000,9999)}"
@@ -288,17 +288,17 @@ def Phone(recordsToGenerate, dType):
         else:
             ddd = str(randint(11, 99))
             number = f"({ddd}) 9{randint(1000,9999)}-{randint(1000,9999)}"
-        dataList.append(f"'{number}'")
-    return dataList
+        data_list.append(f"'{number}'")
+    return data_list
 
 
-def CNPJ(recordsToGenerate, dType):
+def CNPJ(records_to_generate, data_type):
     """
     Gera CNPJs válidos (com dígitos verificadores corretos).
     Formato: XX.XXX.XXX/0001-XX
     """
-    dataList = []
-    for _ in range(recordsToGenerate):
+    data_list = []
+    for _ in range(records_to_generate):
         base = [random.randint(0, 9) for _ in range(8)] + [0, 0, 0, 1]
 
         # Primeiro dígito verificador
@@ -312,11 +312,11 @@ def CNPJ(recordsToGenerate, dType):
         base.append(0 if val < 2 else 11 - val)
 
         cnpj = '%s%s.%s%s%s.%s%s%s/%s%s%s%s-%s%s' % tuple(base)
-        dataList.append(f"'{cnpj}'")
-    return dataList
+        data_list.append(f"'{cnpj}'")
+    return data_list
 
 
-def CEP(recordsToGenerate, dType):
+def CEP(records_to_generate, data_type):
     """
     Gera CEPs aleatórios no formato XXXXX-XXX.
     USO:
@@ -336,10 +336,10 @@ def CEP(recordsToGenerate, dType):
         'SC': (88000, 89999), 'RS': (90000, 99999),
     }
 
-    dataList = []
-    for _ in range(recordsToGenerate):
-        if ":" in dType:
-            uf = dType.split(":")[1].upper()
+    data_list = []
+    for _ in range(records_to_generate):
+        if ":" in data_type:
+            uf = data_type.split(":")[1].upper()
             if uf in uf_ranges:
                 prefix = randint(*uf_ranges[uf])
             else:
@@ -349,21 +349,21 @@ def CEP(recordsToGenerate, dType):
 
         suffix = randint(0, 999)
         cep = f"{prefix:05d}-{suffix:03d}"
-        dataList.append(f"'{cep}'")
-    return dataList
+        data_list.append(f"'{cep}'")
+    return data_list
 
 
-def UUID(recordsToGenerate, dType):
+def UUID(records_to_generate, data_type):
     """
     Gera UUIDs v4 aleatórios.
     """
-    dataList = []
-    for _ in range(recordsToGenerate):
-        dataList.append(f"'{_uuid.uuid4()}'")
-    return dataList
+    data_list = []
+    for _ in range(records_to_generate):
+        data_list.append(f"'{_uuid.uuid4()}'")
+    return data_list
 
 
-def Boolean(recordsToGenerate, dType):
+def Boolean(records_to_generate, data_type):
     """
     Gera valores booleanos aleatórios.
     USO:
@@ -371,15 +371,15 @@ def Boolean(recordsToGenerate, dType):
         Boolean:int      -> 1/0
         Boolean:bit      -> 1/0 (alias de int)
     """
-    dataList = []
-    for _ in range(recordsToGenerate):
+    data_list = []
+    for _ in range(records_to_generate):
         val = random.choice([True, False])
-        if ":" in dType:
-            param = dType.split(":")[1].lower()
+        if ":" in data_type:
+            param = data_type.split(":")[1].lower()
             if param in ('int', 'bit'):
-                dataList.append(1 if val else 0)
+                data_list.append(1 if val else 0)
             else:
-                dataList.append('TRUE' if val else 'FALSE')
+                data_list.append('TRUE' if val else 'FALSE')
         else:
-            dataList.append('TRUE' if val else 'FALSE')
-    return dataList
+            data_list.append('TRUE' if val else 'FALSE')
+    return data_list

--- a/table_populator.py
+++ b/table_populator.py
@@ -9,7 +9,7 @@ __author__ = "Luiz F. P. Quirino"
 __copyright__ = "Copyleft 2020, Planet Earth"
 __credits__ = ["LuizQuirino"]
 __license__ = "GPL v3"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __maintainer__ = "LuizQuirino"
 __email__ = "luizfpq@gmail.com"
 __status__ = "Dev"
@@ -20,78 +20,77 @@ import os
 from generators.DataLoader import *
 from generators.Getters import *
 
-def obter_proximo_numero():
-    arquivos = glob.glob('results/*.sql')
-    numeros = [int(os.path.basename(arquivo).split('_')[0]) for arquivo in arquivos if arquivo]
-    return max(numeros) + 1 if numeros else 0
+
+def _get_next_number():
+    files = glob.glob('results/*.sql')
+    numbers = [int(os.path.basename(f).split('_')[0]) for f in files if f]
+    return max(numbers) + 1 if numbers else 0
+
 
 def main():
-    numero = obter_proximo_numero()
-    numero_formatado = f"{numero:02d}"
+    num = _get_next_number()
     dir_path = 'results'
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
-    nome_arquivo = f"{dir_path}/{numero_formatado}_saida.sql"
-    
-    with open(nome_arquivo, 'w') as sql_file:
+    output_file = f"{dir_path}/{num:02d}_saida.sql"
+
+    with open(output_file, 'w') as sql_file:
         for file in glob.glob("tables/*.json"):
             with open(file, 'r') as f:
                 table_dict = json.load(f)
-                tableName = get_table_name(table_dict)
-                recordsToGenerate = get_count_records_to_generate(table_dict)
-                CountFieldListSize = get_count_field_list(table_dict)
 
-                ValueDict = []  # Armazena todos os valores gerados
-                FullNameValues = []  # Armazena os nomes completos
+                table_name = get_table_name(table_dict)
+                records_to_generate = get_count_records_to_generate(table_dict)
+                field_count = get_count_field_list(table_dict)
 
-                DataList = list(table_dict[0]['DataType'].split(","))
+                value_dict = []
+                fullname_values = []
+
+                data_list = [item.strip() for item in table_dict[0]['DataType'].split(",")]
 
                 # Gera FullName primeiro (necessário para FirstName, LastName, UserName, Email)
-                has_fullname_field = any('FullName' in item for item in DataList)
-                needs_fullname = any(k in item for item in DataList for k in ['FirstName', 'LastName', 'UserName', 'Email'])
+                has_fullname_field = any('FullName' in item for item in data_list)
+                needs_fullname = any(
+                    k in item for item in data_list
+                    for k in ['FirstName', 'LastName', 'UserName', 'Email']
+                )
 
                 if has_fullname_field or needs_fullname:
-                    for i, item in enumerate(DataList):
+                    for item in data_list:
                         if 'FullName' in item:
-                            FullNameValues = DataLoad(recordsToGenerate, item.strip(), ValueDict)
+                            fullname_values = DataLoad(records_to_generate, item, value_dict)
                             break
                     else:
-                        # Não há campo FullName explícito, mas precisa gerar para derivar nomes
-                        FullNameValues = DataLoad(recordsToGenerate, 'FullName', ValueDict)
+                        fullname_values = DataLoad(records_to_generate, 'FullName', value_dict)
 
                 # Gera os outros campos
-                for item in DataList:
+                for item in data_list:
                     if 'FullName' not in item:
-                        # Passa FullNameValues para as funções que precisam
                         if any(k in item for k in ['FirstName', 'LastName', 'UserName', 'Email']):
-                            values = DataLoad(recordsToGenerate, item.strip(), [FullNameValues])
+                            values = DataLoad(records_to_generate, item, [fullname_values])
                         else:
-                            values = DataLoad(recordsToGenerate, item.strip(), ValueDict)
-                        ValueDict.append(values)
+                            values = DataLoad(records_to_generate, item, value_dict)
+                        value_dict.append(values)
 
-                # Adiciona FullName ao ValueDict apenas se solicitado no DataType
-                for i, item in enumerate(DataList):
+                # Insere FullName na posição correta se estava no DataType
+                for i, item in enumerate(data_list):
                     if 'FullName' in item:
-                        ValueDict.insert(i, [f"{name}" for name in FullNameValues])
+                        value_dict.insert(i, [f"{name}" for name in fullname_values])
                         break
 
-                lineSeparator = ','
-                sql_file.write(f"INSERT INTO \n\t\"{tableName}\" ({table_dict[0]['FieldList']}) \nVALUES\n")
-                
-                for i in range(recordsToGenerate):
-                    values = ''
-                    FieldValue = 0
-                    
-                    while FieldValue < CountFieldListSize:
-                        values += f"{ValueDict[FieldValue][i]}, "
-                        FieldValue += 1
-                    
-                    if i == recordsToGenerate - 1:
-                        lineSeparator = ';'
-                    
-                    sql_file.write(f"\t({values[:-2]}){lineSeparator}\n")
-    
-    print(f"Arquivo SQL gerado e salvo em '{nome_arquivo}'.")
+                sql_file.write(
+                    f'INSERT INTO \n\t"{table_name}" ({table_dict[0]["FieldList"]}) \nVALUES\n'
+                )
+
+                for i in range(records_to_generate):
+                    row_values = ', '.join(
+                        str(value_dict[col][i]) for col in range(field_count)
+                    )
+                    separator = ';' if i == records_to_generate - 1 else ','
+                    sql_file.write(f"\t({row_values}){separator}\n")
+
+    print(f"Arquivo SQL gerado e salvo em '{output_file}'.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Resumo

Normaliza o naming de variáveis e parâmetros internos para snake_case, mantendo PascalCase apenas nos nomes de tipo (geradores). Inclui também a atualização completa do README.

## Convenção adotada

| Tipo | Estilo | Exemplos |
|------|--------|----------|
| Funções geradoras (API pública) | PascalCase | `FullName`, `Serial`, `DataLoad` |
| Funções internas/helpers | snake_case | `get_table_name`, `_generate_values` |
| Parâmetros | snake_case | `records_to_generate`, `data_type`, `value_dict` |
| Variáveis locais | snake_case | `data_list`, `fullname_values`, `field_count` |

## Arquivos modificados

- `generators/DataLoader.py` — parâmetros renomeados
- `generators/Getters.py` — simplificado e limpo
- `generators/NumericTypes.py` — reescrito (mais conciso)
- `generators/DateTime.py` — parâmetros e variáveis
- `generators/TextTypes.py` — parâmetros e variáveis internas
- `table_populator.py` — variáveis internas
- `cli.py` — `_generate_values()` e funções populate
- `README.md` — documentação completa da CLI, tipos, formatos e exemplos

## Testado

- Todos os tipos geram dados corretamente (SQL, CSV, JSON)
- Formatos de input (JSON, YAML, TOML) continuam funcionais
- `table_populator.py` legado continua operando

Closes #19
Closes #18