### PR TITLE
refactor: qualidade de produção + testes pytest

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
-# -*- coding:utf-8 -*-
 """
-    Lebre CLI — command-line interface for the database populator.
+Lebre CLI — command-line interface for the database populator.
 
-    Usage:
-        lebre create-table --name tbl_users --fields "id,nome,email" \
-                           --types "Serial,FullName,Email" --records 100
-        lebre populate [--tables-dir tables] [--output-dir results] [--format sql]
-        lebre list-types
+Usage:
+    lebre create-table --name tbl_users --fields "id,nome,email" \
+                       --types "Serial,FullName,Email" --records 100
+    lebre populate [--tables-dir tables] [--output-dir results] [--format sql]
+    lebre list-types
 """
+
+from __future__ import annotations
+
 __author__ = "Luiz F. P. Quirino"
 __copyright__ = "Copyleft 2020, Planet Earth"
 __license__ = "GPL v3"
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 import argparse
 import json
@@ -27,16 +29,28 @@ try:
 except ImportError:
     HAS_YAML = False
 
-from generators.DataLoader import DataLoad
+from generators.DataLoader import DataLoad, GeneratorError
 from generators.Getters import get_table_name, get_count_records_to_generate, get_count_field_list
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class LebreError(Exception):
+    """Erro de operação do CLI."""
+
+
+class TableFileError(LebreError):
+    """Erro ao carregar/validar arquivo de tabela."""
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def get_next_number(directory, extension):
-    """Determina o próximo número sequencial para arquivos no formato NN_nome.ext"""
+def get_next_number(directory: str, extension: str) -> int:
+    """Determina o próximo número sequencial para arquivos no formato NN_nome.ext."""
     if not os.path.exists(directory):
         os.makedirs(directory)
 
@@ -51,42 +65,82 @@ def get_next_number(directory, extension):
     return max(numbers) + 1 if numbers else 0
 
 
-def _load_table_file(filepath):
-    """Carrega definição de tabela de JSON, YAML ou TOML. Retorna lista de dicts."""
+def _load_table_file(filepath: str) -> list[dict]:
+    """
+    Carrega definição de tabela de JSON, YAML ou TOML.
+    Retorna lista de dicts validada.
+    """
+    if not os.path.isfile(filepath):
+        raise TableFileError(f"Arquivo não encontrado: '{filepath}'")
+
     ext = os.path.splitext(filepath)[1].lower()
 
-    if ext == '.json':
-        with open(filepath, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-    elif ext in ('.yaml', '.yml'):
-        if not HAS_YAML:
-            print("Erro: pacote 'pyyaml' não instalado. Instale com: pip install pyyaml",
-                  file=sys.stderr)
-            sys.exit(1)
-        with open(filepath, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
-    elif ext == '.toml':
-        with open(filepath, 'rb') as f:
-            data = tomllib.load(f)
-        # TOML retorna dict; normalizar para lista
-        if isinstance(data, dict) and 'TableName' in data:
-            data = [data]
-        elif isinstance(data, dict) and 'table' in data:
-            # suporte a [table] como seção
-            data = [data['table']]
-    else:
-        print(f"Formato não suportado: '{ext}'. Use .json, .yaml ou .toml.", file=sys.stderr)
-        sys.exit(1)
+    try:
+        if ext == '.json':
+            with open(filepath, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        elif ext in ('.yaml', '.yml'):
+            if not HAS_YAML:
+                raise TableFileError(
+                    "Pacote 'pyyaml' não instalado. Instale com: pip install 'lebre[yaml]'"
+                )
+            with open(filepath, 'r', encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+        elif ext == '.toml':
+            with open(filepath, 'rb') as f:
+                data = tomllib.load(f)
+            if isinstance(data, dict) and 'TableName' in data:
+                data = [data]
+            elif isinstance(data, dict) and 'table' in data:
+                data = [data['table']]
+        else:
+            raise TableFileError(
+                f"Formato não suportado: '{ext}'. Use .json, .yaml ou .toml."
+            )
+    except (json.JSONDecodeError, ValueError, tomllib.TOMLDecodeError) as exc:
+        raise TableFileError(f"Erro de parse em '{filepath}': {exc}") from exc
 
     # Normalizar: se veio dict solto, envelopar em lista
     if isinstance(data, dict):
         data = [data]
 
+    if not data:
+        raise TableFileError(f"Arquivo vazio ou inválido: '{filepath}'")
+
+    # Validar campos obrigatórios
+    required_keys = ('TableName', 'FieldList', 'DataType', 'RecordsToGenerate')
+    for i, table in enumerate(data):
+        if not isinstance(table, dict):
+            raise TableFileError(
+                f"Entrada #{i} em '{filepath}' não é um dicionário válido"
+            )
+        missing = [k for k in required_keys if k not in table]
+        if missing:
+            raise TableFileError(
+                f"Campos obrigatórios ausentes em '{filepath}': {', '.join(missing)}"
+            )
+        # Validar consistência fields vs types
+        fields = [f.strip() for f in table['FieldList'].split(',')]
+        types = [t.strip() for t in table['DataType'].split(',')]
+        if len(fields) != len(types):
+            raise TableFileError(
+                f"Inconsistência em '{filepath}' tabela '{table['TableName']}': "
+                f"{len(fields)} campos mas {len(types)} tipos definidos"
+            )
+        if not isinstance(table['RecordsToGenerate'], int) or table['RecordsToGenerate'] <= 0:
+            raise TableFileError(
+                f"RecordsToGenerate deve ser inteiro > 0 em '{filepath}', "
+                f"recebeu: {table['RecordsToGenerate']}"
+            )
+
     return data
 
 
-def _find_table_files(tables_dir):
+def _find_table_files(tables_dir: str) -> list[str]:
     """Busca todos os arquivos de tabela suportados no diretório, ordenados."""
+    if not os.path.isdir(tables_dir):
+        raise LebreError(f"Diretório de tabelas não encontrado: '{tables_dir}'")
+
     patterns = ['*.json', '*.yaml', '*.yml', '*.toml']
     files = []
     for pat in patterns:
@@ -110,10 +164,20 @@ AVAILABLE_TYPES = [
 # create-table
 # ---------------------------------------------------------------------------
 
-def cmd_create_table(args):
+def cmd_create_table(args: argparse.Namespace) -> None:
     """Cria um arquivo de definição de tabela (JSON, YAML ou TOML)."""
     tables_dir = args.tables_dir
     table_format = args.table_format
+
+    # Validar consistência de campos e tipos
+    fields = [f.strip() for f in args.fields.split(',')]
+    types = [t.strip() for t in args.types.split(',')]
+    if len(fields) != len(types):
+        print(
+            f"Erro: número de campos ({len(fields)}) difere do número de tipos ({len(types)}).",
+            file=sys.stderr
+        )
+        sys.exit(1)
 
     table = {
         "TableName": args.name,
@@ -125,23 +189,29 @@ def cmd_create_table(args):
     num = get_next_number(tables_dir, table_format)
     filename = os.path.join(tables_dir, f"{num:02d}_{args.name}.{table_format}")
 
-    if table_format == 'json':
-        with open(filename, 'w', encoding='utf-8') as f:
-            json.dump([table], f, indent=4, ensure_ascii=False)
-    elif table_format in ('yaml', 'yml'):
-        if not HAS_YAML:
-            print("Erro: pacote 'pyyaml' não instalado. Instale com: pip install pyyaml",
-                  file=sys.stderr)
-            sys.exit(1)
-        with open(filename, 'w', encoding='utf-8') as f:
-            yaml.dump(table, f, default_flow_style=False, allow_unicode=True)
-    elif table_format == 'toml':
-        with open(filename, 'w', encoding='utf-8') as f:
-            f.write('[table]\n')
-            f.write(f'TableName = "{table["TableName"]}"\n')
-            f.write(f'FieldList = "{table["FieldList"]}"\n')
-            f.write(f'DataType = "{table["DataType"]}"\n')
-            f.write(f'RecordsToGenerate = {table["RecordsToGenerate"]}\n')
+    try:
+        if table_format == 'json':
+            with open(filename, 'w', encoding='utf-8') as f:
+                json.dump([table], f, indent=4, ensure_ascii=False)
+        elif table_format in ('yaml', 'yml'):
+            if not HAS_YAML:
+                print(
+                    "Erro: pacote 'pyyaml' não instalado. Instale com: pip install 'lebre[yaml]'",
+                    file=sys.stderr
+                )
+                sys.exit(1)
+            with open(filename, 'w', encoding='utf-8') as f:
+                yaml.dump(table, f, default_flow_style=False, allow_unicode=True)
+        elif table_format == 'toml':
+            with open(filename, 'w', encoding='utf-8') as f:
+                f.write('[table]\n')
+                f.write(f'TableName = "{table["TableName"]}"\n')
+                f.write(f'FieldList = "{table["FieldList"]}"\n')
+                f.write(f'DataType = "{table["DataType"]}"\n')
+                f.write(f'RecordsToGenerate = {table["RecordsToGenerate"]}\n')
+    except OSError as exc:
+        print(f"Erro ao salvar tabela: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Tabela salva em '{filename}'.")
 
@@ -150,14 +220,19 @@ def cmd_create_table(args):
 # populate
 # ---------------------------------------------------------------------------
 
-def cmd_populate(args):
+def cmd_populate(args: argparse.Namespace) -> None:
     """Gera arquivo de saída a partir das definições em tables_dir."""
     tables_dir = args.tables_dir
     output_dir = args.output_dir
     output_format = args.format
     use_stdout = args.stdout
 
-    table_files = _find_table_files(tables_dir)
+    try:
+        table_files = _find_table_files(tables_dir)
+    except LebreError as exc:
+        print(f"Erro: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     if not table_files:
         print(f"Nenhuma tabela encontrada em '{tables_dir}/'.", file=sys.stderr)
         sys.exit(1)
@@ -168,80 +243,93 @@ def cmd_populate(args):
         num = get_next_number(output_dir, output_format)
         output_file = os.path.join(output_dir, f"{num:02d}_saida.{output_format}")
 
-    if output_format == 'sql':
-        _populate_sql(table_files, output_file, dialect=args.dialect)
-    elif output_format == 'csv':
-        _populate_csv(table_files, output_file)
-    elif output_format == 'json':
-        _populate_json(table_files, output_file)
-    else:
-        print(f"Formato '{output_format}' não suportado.", file=sys.stderr)
+    try:
+        if output_format == 'sql':
+            _populate_sql(table_files, output_file, dialect=args.dialect)
+        elif output_format == 'csv':
+            _populate_csv(table_files, output_file)
+        elif output_format == 'json':
+            _populate_json(table_files, output_file)
+        else:
+            print(f"Formato '{output_format}' não suportado.", file=sys.stderr)
+            sys.exit(1)
+    except (TableFileError, GeneratorError) as exc:
+        print(f"Erro ao gerar dados: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Erro de I/O: {exc}", file=sys.stderr)
         sys.exit(1)
 
     if not use_stdout:
         print(f"Arquivo gerado: '{output_file}'.")
 
 
-def _generate_values(table_dict):
-    """Gera value_dict para uma definição de tabela (lógica extraída do table_populator)."""
+def _generate_values(table_dict: list[dict]) -> tuple[list[list], int, int]:
+    """
+    Gera value_dict para uma definição de tabela.
+
+    Returns:
+        (value_dict, records, field_count)
+    """
     records = get_count_records_to_generate(table_dict)
     field_count = get_count_field_list(table_dict)
     data_list = [item.strip() for item in table_dict[0]['DataType'].split(",")]
 
-    value_dict = []
-    fullname_values = []
+    value_dict: list[list] = []
+    fullname_values: list[str] = []
 
     # Gera FullName primeiro (necessário para FirstName, LastName, UserName, Email)
+    dependent_types = ('FirstName', 'LastName', 'UserName', 'Email')
     has_fullname_field = any('FullName' in item for item in data_list)
-    needs_fullname = any(k in item for item in data_list for k in ['FirstName', 'LastName', 'UserName', 'Email'])
+    needs_fullname = any(
+        dep in item for item in data_list for dep in dependent_types
+    )
 
     if has_fullname_field or needs_fullname:
         for item in data_list:
             if 'FullName' in item:
-                fullname_values = DataLoad(records, item.strip(), value_dict)
+                fullname_values = DataLoad(records, item, value_dict)
                 break
         else:
             fullname_values = DataLoad(records, 'FullName', value_dict)
 
     # Gera os outros campos
     for item in data_list:
-        if 'FullName' not in item:
-            if any(k in item for k in ['FirstName', 'LastName', 'UserName', 'Email']):
-                values = DataLoad(records, item.strip(), [fullname_values])
-            else:
-                values = DataLoad(records, item.strip(), value_dict)
-            value_dict.append(values)
+        if 'FullName' in item:
+            continue  # será inserido na posição correta depois
+        if any(dep in item for dep in dependent_types):
+            values = DataLoad(records, item, [fullname_values])
+        else:
+            values = DataLoad(records, item, value_dict)
+        value_dict.append(values)
 
     # Insere FullName na posição correta se estava no DataType
     for i, item in enumerate(data_list):
         if 'FullName' in item:
-            value_dict.insert(i, [f"{name}" for name in fullname_values])
+            value_dict.insert(i, [name for name in fullname_values])
             break
 
     return value_dict, records, field_count
 
 
-def _quote_identifier(name, dialect):
+def _quote_identifier(name: str, dialect: str) -> str:
     """Aplica quoting ao nome de tabela/coluna conforme o dialeto SQL."""
     if dialect == 'mysql':
         return f'`{name}`'
     elif dialect == 'postgresql':
         return f'"{name}"'
-    else:  # sqlite
-        return name
+    return name  # sqlite
 
 
-def _populate_sql(table_files, output_file, dialect='postgresql'):
+def _populate_sql(table_files: list[str], output_file: str | None, dialect: str = 'postgresql') -> None:
     """Gera saída no formato SQL INSERT."""
     fh = open(output_file, 'w', encoding='utf-8') if output_file else sys.stdout
     try:
         for tf in table_files:
             table_dict = _load_table_file(tf)
-
             table_name = get_table_name(table_dict)
             value_dict, records, field_count = _generate_values(table_dict)
 
-            # Quoting do nome da tabela e campos
             quoted_table = _quote_identifier(table_name, dialect)
             fields = [f.strip() for f in table_dict[0]['FieldList'].split(',')]
             quoted_fields = ', '.join(_quote_identifier(f, dialect) for f in fields)
@@ -253,47 +341,41 @@ def _populate_sql(table_files, output_file, dialect='postgresql'):
                 separator = ';' if i == records - 1 else ','
                 fh.write(f"\t({values}){separator}\n")
     finally:
-        if output_file:
+        if output_file and fh is not sys.stdout:
             fh.close()
 
 
-def _populate_csv(table_files, output_file):
-    """Gera saída no formato CSV (uma tabela por seção, separadas por linha em branco)."""
+def _populate_csv(table_files: list[str], output_file: str | None) -> None:
+    """Gera saída no formato CSV."""
     fh = open(output_file, 'w', encoding='utf-8') if output_file else sys.stdout
     try:
         for tf in table_files:
             table_dict = _load_table_file(tf)
-
             fields = [field.strip() for field in table_dict[0]['FieldList'].split(',')]
             value_dict, records, field_count = _generate_values(table_dict)
 
-            # Header
             fh.write(','.join(fields) + '\n')
 
-            # Rows
             for i in range(records):
                 row = []
                 for col in range(field_count):
                     val = str(value_dict[col][i])
-                    # Remove aspas SQL simples para CSV
                     if val.startswith("'") and val.endswith("'"):
                         val = val[1:-1]
                     row.append(val)
                 fh.write(','.join(row) + '\n')
-
             fh.write('\n')
     finally:
-        if output_file:
+        if output_file and fh is not sys.stdout:
             fh.close()
 
 
-def _populate_json(table_files, output_file):
+def _populate_json(table_files: list[str], output_file: str | None) -> None:
     """Gera saída no formato JSON (array de objetos por tabela)."""
-    output = {}
+    output: dict[str, list[dict]] = {}
 
     for tf in table_files:
         table_dict = _load_table_file(tf)
-
         table_name = get_table_name(table_dict)
         fields = [field.strip() for field in table_dict[0]['FieldList'].split(',')]
         value_dict, records, field_count = _generate_values(table_dict)
@@ -303,12 +385,10 @@ def _populate_json(table_files, output_file):
             row = {}
             for col in range(field_count):
                 val = value_dict[col][i]
-                # Remove aspas SQL simples para JSON
                 if isinstance(val, str) and val.startswith("'") and val.endswith("'"):
                     val = val[1:-1]
                 row[fields[col]] = val
             rows.append(row)
-
         output[table_name] = rows
 
     fh = open(output_file, 'w', encoding='utf-8') if output_file else sys.stdout
@@ -316,7 +396,7 @@ def _populate_json(table_files, output_file):
         json.dump(output, fh, indent=2, ensure_ascii=False)
         fh.write('\n')
     finally:
-        if output_file:
+        if output_file and fh is not sys.stdout:
             fh.close()
 
 
@@ -324,7 +404,7 @@ def _populate_json(table_files, output_file):
 # list-types
 # ---------------------------------------------------------------------------
 
-def cmd_list_types(args):
+def cmd_list_types(args: argparse.Namespace) -> None:
     """Lista os tipos de dados disponíveis."""
     print("Tipos de dados disponíveis:\n")
     for t in AVAILABLE_TYPES:
@@ -340,7 +420,7 @@ def cmd_list_types(args):
 # Parser
 # ---------------------------------------------------------------------------
 
-def build_parser():
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog='lebre',
         description='Lebre — Database Populator. Gera dados fictícios para popular tabelas.',
@@ -357,12 +437,12 @@ def build_parser():
     ct.add_argument('--records', type=int, required=True, help='Número de registros a gerar')
     ct.add_argument('--tables-dir', default='tables', help='Diretório para salvar (default: tables)')
     ct.add_argument('--table-format', choices=['json', 'yaml', 'toml'], default='json',
-                     help='Formato do arquivo de tabela (default: json)')
+                    help='Formato do arquivo de tabela (default: json)')
     ct.set_defaults(func=cmd_create_table)
 
     # populate
     pop = subparsers.add_parser('populate', help='Gera dados a partir das tabelas definidas')
-    pop.add_argument('--tables-dir', default='tables', help='Diretório com JSONs de tabela (default: tables)')
+    pop.add_argument('--tables-dir', default='tables', help='Diretório com definições de tabela (default: tables)')
     pop.add_argument('--output-dir', default='results', help='Diretório de saída (default: results)')
     pop.add_argument('--format', choices=['sql', 'csv', 'json'], default='sql',
                      help='Formato de saída (default: sql)')
@@ -379,7 +459,7 @@ def build_parser():
     return parser
 
 
-def main():
+def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 

--- a/generators/DataLoader.py
+++ b/generators/DataLoader.py
@@ -1,81 +1,125 @@
 #!/usr/bin/env python3
-# -*- coding:utf-8 -*-
 """
-    Dataloader defines data types and load them all from datasource files
+Dispatcher de tipos de dados — roteia para o gerador correto conforme data_type.
 """
-__author__ = "Luiz F. P. Quirino"
-__copyright__ = "Copyleft 2020, Planet Earth"
-__credits__ = ["LuizQuirino"]
-__license__ = "GPL v3"
-__version__ = "2.1.0"
-__maintainer__ = "LuizQuirino"
-__email__ = "luizfpq@gmail.com"
-__status__ = "Dev"
+
+from __future__ import annotations
+
+from generators.TextTypes import (
+    FullName, FirstName, LastName, UserName, Email, InitName,
+    Sex, CPF, CNPJ, Phone, CEP, UUID, Boolean,
+    Varchar, Address, City, StateProvince,
+    GeneratorError,
+)
+from generators.DateTime import Date, DateTime
+from generators.NumericTypes import Serial, Integer
+
+__all__ = ["DataLoad", "GeneratorError"]
 
 
-import random
+# ---------------------------------------------------------------------------
+# Dispatch table — mapeia prefixo do tipo para (função, aceita_value_dict)
+# ---------------------------------------------------------------------------
 
-from generators.TextTypes import *
-from generators.DateTime import *
-from generators.NumericTypes import *
+# Geradores que NÃO recebem value_dict (independentes)
+_INDEPENDENT_GENERATORS: dict[str, callable] = {
+    'Serial': Serial,
+    'Integer': Integer,
+    'FullName': FullName,
+    'CPF': CPF,
+    'CNPJ': CNPJ,
+    'Phone': Phone,
+    'CEP': CEP,
+    'UUID': UUID,
+    'Boolean': Boolean,
+    'Varchar': Varchar,
+    'Sex': Sex,
+    'Address': Address,
+    'Date': Date,
+    'DateTime': DateTime,
+}
+
+# Geradores que RECEBEM value_dict (dependem de campos anteriores)
+_DEPENDENT_GENERATORS: dict[str, callable] = {
+    'FirstName': FirstName,
+    'LastName': LastName,
+    'UserName': UserName,
+    'Email': Email,
+    'InitName': InitName,
+    'City': City,
+    'StateProvince': StateProvince,
+}
+
+# Ordem de resolução — tipos mais específicos primeiro para evitar match parcial
+# (ex: "DateTime" antes de "Date", "StateProvince" antes de qualquer substring)
+_DISPATCH_ORDER: list[tuple[str, callable, bool]] = [
+    # (prefixo, função, requer_value_dict)
+    ('DateTime', DateTime, False),
+    ('Date', Date, False),
+    ('StateProvince', StateProvince, True),
+    ('FirstName', FirstName, True),
+    ('LastName', LastName, True),
+    ('FullName', FullName, False),
+    ('UserName', UserName, True),
+    ('Email', Email, True),
+    ('InitName', InitName, True),
+    ('Serial', Serial, False),
+    ('Integer', Integer, False),
+    ('CPF', CPF, False),
+    ('CNPJ', CNPJ, False),
+    ('Phone', Phone, False),
+    ('CEP', CEP, False),
+    ('UUID', UUID, False),
+    ('Boolean', Boolean, False),
+    ('Varchar', Varchar, False),
+    ('Sex', Sex, False),
+    ('Address', Address, False),
+    ('City', City, True),
+    ('Default', None, False),
+]
 
 
-def DataLoad(records_to_generate, data_type, value_dict):
+def DataLoad(records_to_generate: int, data_type: str, value_dict: list) -> list:
     """
     Dispatcher principal — roteia para o gerador correto conforme data_type.
-    Nomes de tipo usam PascalCase (API pública dos geradores).
+
+    Args:
+        records_to_generate: Número de registros a gerar.
+        data_type: Tipo de dado (ex: 'Serial', 'CPF', 'FullName', 'Integer:0:100').
+        value_dict: Lista de campos já gerados (para tipos dependentes).
+
+    Returns:
+        Lista com os valores gerados.
+
+    Raises:
+        GeneratorError: Se o tipo não for reconhecido ou houver erro de configuração.
     """
+    if records_to_generate <= 0:
+        raise GeneratorError(
+            f"records_to_generate deve ser > 0, recebeu {records_to_generate}"
+        )
 
-    # --- TextTypes ---
-    if 'FullName' in data_type:
-        return FullName(records_to_generate, data_type)
-    if 'FirstName' in data_type:
-        return FirstName(records_to_generate, data_type, value_dict)
-    if 'LastName' in data_type:
-        return LastName(records_to_generate, data_type, value_dict)
-    if 'Email' in data_type:
-        return Email(records_to_generate, data_type, value_dict)
-    if data_type == 'InitName':
-        return InitName(records_to_generate, data_type, value_dict)
-    if data_type == 'UserName' or data_type.startswith('UserName:'):
-        return UserName(records_to_generate, data_type, value_dict)
-    if data_type == 'Sex':
-        return Sex(records_to_generate, data_type)
-    if data_type == 'CPF':
-        return CPF(records_to_generate, data_type)
-    if "Varchar" in data_type:
-        return Varchar(records_to_generate, data_type)
-    if "Address" in data_type:
-        return Address(records_to_generate, data_type)
-    if "City" in data_type:
-        return City(records_to_generate, data_type, value_dict)
-    if "StateProvince" in data_type:
-        return StateProvince(records_to_generate, data_type, value_dict)
+    data_type = data_type.strip()
 
-    # --- NumericTypes ---
-    if 'Serial' in data_type:
-        return Serial(records_to_generate, data_type)
-    if 'Integer' in data_type:
-        return Integer(records_to_generate, data_type)
+    for prefix, generator_fn, needs_value_dict in _DISPATCH_ORDER:
+        if prefix in data_type:
+            # Caso especial: Default retorna valor fixo
+            if prefix == 'Default':
+                parts = data_type.split(":", 1)
+                if len(parts) < 2:
+                    raise GeneratorError(
+                        f"Formato inválido para Default: '{data_type}'. "
+                        "Esperado: Default:valor (ex: Default:'ativo')"
+                    )
+                value = parts[1]
+                return [value] * records_to_generate
 
-    # --- DateTimeTypes ---
-    if 'Date' in data_type and 'DateTime' not in data_type:
-        return Date(records_to_generate, data_type)
-    if 'DateTime' in data_type:
-        return DateTime(records_to_generate, data_type)
+            if needs_value_dict:
+                return generator_fn(records_to_generate, data_type, value_dict)
+            else:
+                return generator_fn(records_to_generate, data_type)
 
-    # --- Default (retorna valor fixo) ---
-    if "Default" in data_type:
-        return [data_type.split(":")[1] for _ in range(records_to_generate)]
-
-    # --- Novos tipos v2.1 ---
-    if 'Phone' in data_type:
-        return Phone(records_to_generate, data_type)
-    if 'CNPJ' in data_type:
-        return CNPJ(records_to_generate, data_type)
-    if 'CEP' in data_type:
-        return CEP(records_to_generate, data_type)
-    if 'UUID' in data_type:
-        return UUID(records_to_generate, data_type)
-    if 'Boolean' in data_type:
-        return Boolean(records_to_generate, data_type)
+    raise GeneratorError(
+        f"Tipo de dado desconhecido: '{data_type}'. "
+        f"Use 'lebre list-types' para ver os tipos disponíveis."
+    )

--- a/generators/DateTime.py
+++ b/generators/DateTime.py
@@ -1,80 +1,99 @@
 #!/usr/bin/env python3
-# -*- coding:utf-8 -*-
-""" 
-    A Database Populator is a tool which helps you to populate your projects' database tables 
-    with randomly generated content. With this tool you no longer need to write queries or to 
-    compile forms by yourself wasting a lot of time before to start to work on your applications.
-"""
-__author__ = "Luiz F. P. Quirino"
-__copyright__ = "Copyleft 2020, Planet Earth"
-__credits__ = ["LuizQuirino"]
-__license__ = "GPL v3"
-__version__ = "2.0.1"
-__maintainer__ = "LuizQuirino"
-__email__ = "luizfpq@gmail.com"
-__status__ = "Dev"
+"""Geradores de tipos de data e hora."""
+
+from __future__ import annotations
 
 import random
 import time
+from typing import TYPE_CHECKING
 
-def str_time_prop(start, end, fmt, prop):
-    """Get a time at a proportion of a range of two formatted times.
+__all__ = ["Date", "DateTime"]
 
-    start and end should be strings specifying times formatted in the
-    given format (strftime-style), giving an interval [start, end].
-    prop specifies how a proportion of the interval to be taken after
-    start.  The returned time will be in the specified format.
+
+class GeneratorError(Exception):
+    """Erro de configuração ou execução de um gerador."""
+
+
+def _random_timestamp(start_ts: float, end_ts: float) -> float:
+    """Retorna timestamp aleatório entre start_ts e end_ts."""
+    return start_ts + random.random() * (end_ts - start_ts)
+
+
+def _parse_date_range(data_type: str, fmt: str, default_start: str, default_end: str) -> tuple[float, float]:
     """
-
-    stime = time.mktime(time.strptime(start, fmt))
-    etime = time.mktime(time.strptime(end, fmt))
-
-    ptime = stime + prop * (etime - stime)
-
-    return time.strftime(fmt, time.localtime(ptime))
-
-
-def random_date_time(start, end, prop):
-    rand_datetime = str_time_prop(start, end, '%d/%m/%Y %I:%M %p', prop)
-    return '\''+rand_datetime+'\''
-
-def random_date(start, end, prop):
-    rand_date = str_time_prop(start, end, '%d/%m/%Y', prop)
-    return '\''+rand_date+'\''
-
-
-def Date(records_to_generate, data_type):
-    """
-    Gera uma lista de datas aleatórias.
-    USO:
-        Date                        -> data entre 01/01/1970 e 01/01/2000
-        Date:01/01/1990:31/12/2020  -> data no intervalo especificado
+    Extrai e valida intervalo de datas do data_type.
+    Retorna (start_timestamp, end_timestamp).
     """
     if ":" in data_type:
-        parts = data_type.split(":")
-        start = parts[1]
-        end = parts[2]
+        parts = data_type.split(":", 2)
+        if len(parts) < 3:
+            raise GeneratorError(
+                f"Formato inválido: '{data_type}'. "
+                f"Esperado: Tipo:inicio:fim (ex: Date:01/01/2020:31/12/2020)"
+            )
+        start_str, end_str = parts[1], parts[2]
     else:
-        start = "1/1/1970"
-        end = "1/1/2000"
+        start_str, end_str = default_start, default_end
 
-    data_list = []
-    for _ in range(records_to_generate):
-        data_list.append(random_date(start, end, random.random()))
-    return data_list
+    try:
+        start_ts = time.mktime(time.strptime(start_str, fmt))
+    except (ValueError, OverflowError) as exc:
+        raise GeneratorError(
+            f"Data de início inválida: '{start_str}'. Formato esperado: {fmt}"
+        ) from exc
+
+    try:
+        end_ts = time.mktime(time.strptime(end_str, fmt))
+    except (ValueError, OverflowError) as exc:
+        raise GeneratorError(
+            f"Data de fim inválida: '{end_str}'. Formato esperado: {fmt}"
+        ) from exc
+
+    if start_ts > end_ts:
+        raise GeneratorError(
+            f"Data de início ({start_str}) é posterior à data de fim ({end_str})"
+        )
+
+    return start_ts, end_ts
 
 
-def DateTime(records_to_generate, data_type):
+def Date(records_to_generate: int, data_type: str) -> list[str]:
     """
-    Gera uma lista de datas com hora aleatórias.
-    USO:
-        DateTime                                        -> entre 01/01/1970 e 01/01/2000
-        DateTime:01/01/1990 8:00 AM:31/12/2020 6:00 PM -> intervalo especificado
-    """
-    start = "1/1/1970 12:00 AM"
-    end = "1/1/2000 11:59 PM"
+    Gera datas aleatórias no formato dd/mm/yyyy.
 
-    data_list = []
+    Uso:
+        Date                        -> entre 01/01/1970 e 01/01/2000
+        Date:01/01/1990:31/12/2020  -> intervalo especificado
+    """
+    if records_to_generate <= 0:
+        raise GeneratorError(f"records_to_generate deve ser > 0, recebeu {records_to_generate}")
+
+    fmt = '%d/%m/%Y'
+    start_ts, end_ts = _parse_date_range(data_type, fmt, "01/01/1970", "01/01/2000")
+
+    results = []
     for _ in range(records_to_generate):
-        data_list.append(random_date_time(start, end, random.random()))
-    return data_list
+        ts = _random_timestamp(start_ts, end_ts)
+        results.append("'" + time.strftime(fmt, time.localtime(ts)) + "'")
+    return results
+
+
+def DateTime(records_to_generate: int, data_type: str) -> list[str]:
+    """
+    Gera datas com hora aleatórias no formato dd/mm/yyyy HH:MM AM/PM.
+
+    Uso:
+        DateTime  -> entre 01/01/1970 e 01/01/2000
+    """
+    if records_to_generate <= 0:
+        raise GeneratorError(f"records_to_generate deve ser > 0, recebeu {records_to_generate}")
+
+    fmt = '%d/%m/%Y %I:%M %p'
+    start_ts = time.mktime(time.strptime("01/01/1970 12:00 AM", fmt))
+    end_ts = time.mktime(time.strptime("01/01/2000 11:59 PM", fmt))
+
+    results = []
+    for _ in range(records_to_generate):
+        ts = _random_timestamp(start_ts, end_ts)
+        results.append("'" + time.strftime(fmt, time.localtime(ts)) + "'")
+    return results

--- a/generators/NumericTypes.py
+++ b/generators/NumericTypes.py
@@ -1,37 +1,69 @@
 #!/usr/bin/env python3
-# -*- coding:utf-8 -*-
-"""
-    Geradores de tipos numéricos.
-"""
-__author__ = "Luiz F. P. Quirino"
-__copyright__ = "Copyleft 2020, Planet Earth"
-__credits__ = ["LuizQuirino"]
-__license__ = "GPL v3"
-__version__ = "2.1.0"
-__maintainer__ = "LuizQuirino"
-__email__ = "luizfpq@gmail.com"
-__status__ = "Dev"
+"""Geradores de tipos numéricos."""
+
+from __future__ import annotations
 
 import random
 
+__all__ = ["Serial", "Integer"]
 
-def Integer(records_to_generate, data_type):
+
+class GeneratorError(Exception):
+    """Erro de configuração ou execução de um gerador."""
+
+
+def _parse_int(value: str, field_name: str) -> int:
+    """Converte string para int com mensagem de erro clara."""
+    try:
+        return int(value)
+    except (ValueError, TypeError) as exc:
+        raise GeneratorError(
+            f"Valor inválido para '{field_name}': esperado inteiro, recebeu '{value}'"
+        ) from exc
+
+
+def Serial(records_to_generate: int, data_type: str) -> list[int]:
     """
-    Define o tipo inteiro.
-    USO: Integer:min_value:max_value (ex: Integer:0:10)
+    Gera sequência auto-incremento.
+
+    Uso:
+        Serial      -> [0, 1, 2, ...]
+        Serial:N    -> [N, N+1, N+2, ...]
     """
+    if records_to_generate <= 0:
+        raise GeneratorError(f"records_to_generate deve ser > 0, recebeu {records_to_generate}")
+
+    start = 0
+    if ":" in data_type:
+        parts = data_type.split(":", 1)
+        start = _parse_int(parts[1], "Serial:start")
+
+    return list(range(start, start + records_to_generate))
+
+
+def Integer(records_to_generate: int, data_type: str) -> list[int]:
+    """
+    Gera inteiros aleatórios em um intervalo.
+
+    Uso:
+        Integer:min:max  (ex: Integer:0:10)
+    """
+    if records_to_generate <= 0:
+        raise GeneratorError(f"records_to_generate deve ser > 0, recebeu {records_to_generate}")
+
     parts = data_type.split(":")
-    min_val = int(parts[1])
-    max_val = int(parts[2])
+    if len(parts) != 3:
+        raise GeneratorError(
+            f"Formato inválido para Integer: '{data_type}'. "
+            "Esperado: Integer:min:max (ex: Integer:0:100)"
+        )
+
+    min_val = _parse_int(parts[1], "Integer:min")
+    max_val = _parse_int(parts[2], "Integer:max")
+
+    if min_val > max_val:
+        raise GeneratorError(
+            f"Integer: min ({min_val}) não pode ser maior que max ({max_val})"
+        )
+
     return [random.randint(min_val, max_val) for _ in range(records_to_generate)]
-
-
-def Serial(records_to_generate, data_type):
-    """
-    Define o tipo serial (autoincremento).
-    USO:
-        Serial:10  -> inicia em 10
-        Serial     -> inicia em 0
-    """
-    start = int(data_type.split(":")[1]) if ":" in data_type else 0
-    return [start + i for i in range(records_to_generate)]

--- a/generators/TextTypes.py
+++ b/generators/TextTypes.py
@@ -1,385 +1,491 @@
 #!/usr/bin/env python3
-# -*- coding:utf-8 -*-
-"""
-    A Database Populator is a tool which helps you to populate your projects' database tables
-    with randomly generated content. With this tool you no longer need to write queries or to
-    compile forms by yourself wasting a lot of time before to start to work on your applications.
+"""Geradores de tipos textuais e documentos brasileiros."""
 
+from __future__ import annotations
 
-    Aways return strings in this format '\''+randChar+'\'', to pass the '' to variable
-
-
-"""
-__author__ = "Luiz F. P. Quirino"
-__copyright__ = "Copyleft 2020, Planet Earth"
-__credits__ = ["LuizQuirino"]
-__license__ = "GPL v3"
-__version__ = "2.0.1"
-__maintainer__ = "LuizQuirino"
-__email__ = "luizfpq@gmail.com"
-__status__ = "Dev"
-
-import random
-from random import randint
-import string
 import os
+import random
+import string
+import uuid as _uuid
+from random import randint
+
+__all__ = [
+    "FullName", "FirstName", "LastName", "UserName", "Email", "InitName",
+    "Sex", "CPF", "CNPJ", "Phone", "CEP", "UUID", "Boolean",
+    "Varchar", "Address", "City", "StateProvince",
+]
+
 
 # ---------------------------------------------------------------------------
-# Cache de datasources — carrega cada arquivo apenas uma vez em memória
+# Exceptions
 # ---------------------------------------------------------------------------
-_datasource_cache = {}
 
-def _get_datasource(filename):
-    """Retorna as linhas do datasource em cache. Carrega do disco apenas na primeira chamada."""
+class GeneratorError(Exception):
+    """Erro de configuração ou execução de um gerador."""
+
+
+class DatasourceError(GeneratorError):
+    """Erro ao carregar arquivo de datasource."""
+
+
+# ---------------------------------------------------------------------------
+# Cache de datasources
+# ---------------------------------------------------------------------------
+
+_datasource_cache: dict[str, list[str]] = {}
+_DATASOURCES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'datasources'
+)
+
+
+def _get_datasource(filename: str) -> list[str]:
+    """
+    Retorna linhas do datasource em cache.
+    Carrega do disco apenas na primeira chamada.
+    """
     if filename not in _datasource_cache:
-        filepath = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                                'datasources', filename)
-        with open(filepath, 'r', encoding='utf-8') as f:
-            _datasource_cache[filename] = f.read().splitlines()
+        filepath = os.path.join(_DATASOURCES_DIR, filename)
+        if not os.path.isfile(filepath):
+            raise DatasourceError(
+                f"Datasource não encontrado: '{filepath}'. "
+                f"Verifique se o arquivo existe em datasources/"
+            )
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                lines = [line.strip() for line in f if line.strip()]
+        except OSError as exc:
+            raise DatasourceError(f"Erro ao ler datasource '{filename}': {exc}") from exc
+
+        if not lines:
+            raise DatasourceError(f"Datasource vazio: '{filename}'")
+
+        _datasource_cache[filename] = lines
     return _datasource_cache[filename]
 
 
-def _search_in_datasource(filename, search_term):
+def _search_in_datasource(filename: str, search_term: str) -> list[str]:
     """Filtra linhas do datasource que contêm search_term."""
     lines = _get_datasource(filename)
-    return [line for line in lines if search_term in line]
+    results = [line for line in lines if search_term in line]
+    if not results:
+        raise GeneratorError(
+            f"Nenhum resultado para '{search_term}' em '{filename}'"
+        )
+    return results
 
 
-def random_char(y):
-    randChar = ''.join(random.choice(string.ascii_letters) for x in range(y))
-    return '\''+randChar+'\''
-
-
-def CPF(records_to_generate, data_type):
-    '''
-    Gera o cadastro de pessoas físicas, com um valor validável
-    '''
-    data_list = []
-    for i in range(records_to_generate):
-        cpf = [random.randint(0, 9) for x in range(9)]                              
-                                                                                    
-        for _ in range(2):                                                          
-            val = sum([(len(cpf) + 1 - i) * v for i, v in enumerate(cpf)]) % 11      
-                                                                                    
-            cpf.append(11 - val if val > 1 else 0)                                  
-
-        data_list.append('%s%s%s.%s%s%s.%s%s%s-%s%s' % tuple(cpf))
-    return data_list
-
-#def InitName(records_to_generate, data_type, value_dict):
-#    data_list = []
-#    for i in range(records_to_generate):
-#        
-#    return data_list
-
-def FullName(records_to_generate, data_type):
-    """
-    Gera uma lista de nomes completos a partir do arquivo FullNameBR.txt.
-    """
-    data_list = []
-    lines = _get_datasource('FullNameBR.txt')
-    for i in range(records_to_generate):
-        line = random.choice(lines).strip()
-        data_list.append(f"'{line}'")
-    return data_list
-
-def FirstName(records_to_generate, data_type, value_dict):
-    """
-    Gera uma lista de primeiros nomes a partir da lista de nomes completos.
-    """
-    data_list = []
-    for i in range(records_to_generate):
-        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
-        if not fullname:
-            continue  # Ignore se fullname for None ou vazio
-
-        firstname = fullname.split()[0].strip("'")
-        data_list.append(f"'{firstname}'")
-    return data_list
-
-
-def LastName(records_to_generate, data_type, value_dict):
-    """
-    Gera uma lista de sobrenomes a partir da lista de nomes completos.
-    """
-    data_list = []
-    for i in range(records_to_generate):
-        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
-        if not fullname:
-            continue  # Ignore se fullname for None ou vazio
-
-        lastname = fullname.split()[-1].strip("'")
-        data_list.append(f"'{lastname}'")
-    return data_list
-
-
-def UserName(records_to_generate, data_type, value_dict):
-    """
-    Gera uma lista de nomes de usuário a partir da lista de nomes completos.
-    """
-    data_list = []
-    for i in range(records_to_generate):
-        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
-        if not fullname:
-            continue  # Ignore se fullname for None ou vazio
-
-        fullname = fullname.strip("'")  # Remove aspas externas
-        parts = fullname.split()
-        username = (parts[0][0] + parts[-1]).lower()  # Primeiro caractere do primeiro nome + sobrenome
-        if ":" in data_type:
-            if 'Num' in data_type:
-                number = str(randint(0, 999999)).rjust(6, "0")
-                username = username + number
-        data_list.append(f"'{username}'")
-    return data_list
-
-
-def Email(records_to_generate, data_type, value_dict):
-    """
-    Gera uma lista de emails a partir da lista de nomes completos.
-    """
-    data_list = []
-    for i in range(records_to_generate):
-        fullname = value_dict[0][i]  # Assume que FullName é o primeiro no value_dict
-        parts = fullname.strip("'").split()
-        email = (parts[0] + '.' + parts[-1]).lower() + "@example.com"  # Primeiro nome + ponto + sobrenome + @example.com
-        data_list.append(f"'{email}'")
-    return data_list
-
-# TODO migrar listas para dicionarios
-def InitName(records_to_generate, data_type, value_dict):
-    data_list = []
-    for i in range(records_to_generate):
-        # recebemos o primeiro caracter do ultimo nome usado na lista
-        line = str(value_dict[-1][i][1])
-        line = line.split(",")[0]
-        data_list.append('\''+line+'\'')
-    return data_list
-
-def Sex(records_to_generate, data_type):
-    data_list = []
-    lines = _get_datasource('Sex.txt')
-    for i in range(records_to_generate):
-        line = random.choice(lines)
-        data_list.append('\''+line+'\'')
-    return data_list
-
-def Address(records_to_generate, data_type):
-    data_list = []
-    address_lines = _get_datasource('AddressTypeBR.txt')
-    name_lines = _get_datasource('FullNameBR.txt')
-
-    for i in range(records_to_generate):
-        line = random.choice(address_lines)
-        place_type = line.split(",")[0]
-
-        chosen_line = random.choice(name_lines)
-        words = chosen_line.split()
-        num_words_to_select = random.randint(1, 2)
-        selected_words = random.sample(words, min(num_words_to_select, len(words)))
-        line = place_type+' '+' '.join(selected_words)
-        
-        if ":" in data_type:
-            if 'Num' in data_type:
-                number = str(randint(0, 999))
-                line = line + ', ' + number
-                
-        data_list.append('\''+line+'\'')
-    return data_list
-
-def City(records_to_generate, data_type, value_dict):
-    ''' 
-        USO: 
-            caso queira definir uma cidade de estado específico
-            adicione a sigla do estado desejado em maiusculo
-                City:SP
-            caso queira apenas uma cidade aleatória
-                City
-    '''
-    data_list = []
-    if ":" in data_type:
-        lines = _search_in_datasource('CityBR.txt', str(data_type.split(":")[1]))
-    else:
-        lines = _get_datasource('CityBR.txt')
-
-    for i in range(records_to_generate):
-        line = random.choice(lines)
-        if ":" in data_type:
-            line = line.split(",")[2].replace("\n", "")
-        else:
-            line = line.split(",")[2]
-        data_list.append('\''+line+'\'')
-    return data_list
-
-def StateProvince(records_to_generate, data_type, value_dict):
-    ''' 
-        USO: 
-            Caso queira apenas um estado aleatório
-                StateProvince
-            Caso queira um estado específico, use o tipo "Default",
-            e adicione a sigla do estado desejado em maiusculo
-                Default:SP
-            Caso queira que o estado seja compatível com a cidade aleatória
-                StateProvince:Find
-            
-            IMPORTANTE
-            NUNCA USE O FIND COM records_to_generate > 50
-            isso causa um estouro nos indices das listas usadas
-            
-    '''
-    data_list = []
-
-    # Pré-carrega linhas para modos que não dependem de value_dict por registro
-    if ":" in data_type and 'Find' not in data_type:
-        lines = _search_in_datasource('CityBR.txt', str(data_type.split(":")[1]))
-    elif ":" not in data_type:
-        lines = _get_datasource('StateProvinceBR.txt')
-    else:
-        lines = None  # modo Find — depende de cada registro
-
-    for i in range(records_to_generate):
-        if ":" in data_type:
-            if 'Find' in data_type:
-                matched = _search_in_datasource('CityBR.txt', str(value_dict[-1][i].replace("'", '')))
-                line = str(matched[0])
-                line = line.split(",")[0].replace("\n", "")
-            else:
-                line = random.choice(lines)
-                line = line.split(",")[0].replace("\n", "")
-        else:
-            line = random.choice(lines)
-        data_list.append(str('\''+line+'\''))
-    return data_list
-
-def Varchar(records_to_generate, data_type):
-
-    data_list = []
-    for i in range(records_to_generate):
-        data_list.append(random_char(int(data_type.split(":")[1])))
-    return data_list
-
+def _validate_records(records_to_generate: int) -> None:
+    """Valida que o número de registros é positivo."""
+    if records_to_generate <= 0:
+        raise GeneratorError(
+            f"records_to_generate deve ser > 0, recebeu {records_to_generate}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# Novos geradores v2.1
+# Documentos — CPF
 # ---------------------------------------------------------------------------
 
-import uuid as _uuid
-
-
-def Phone(records_to_generate, data_type):
+def CPF(records_to_generate: int, data_type: str) -> list[str]:
     """
-    Gera números de telefone brasileiros.
-    USO:
-        Phone         -> celular com DDD aleatório, formato (XX) 9XXXX-XXXX
-        Phone:fixo    -> fixo com DDD aleatório, formato (XX) XXXX-XXXX
-        Phone:XX      -> celular com DDD específico (ex: Phone:11)
+    Gera CPFs válidos com dígitos verificadores corretos.
+    Formato: XXX.XXX.XXX-XX
     """
-    data_list = []
+    _validate_records(records_to_generate)
+    results = []
     for _ in range(records_to_generate):
-        if ":" in data_type:
-            param = data_type.split(":")[1]
-            if param == 'fixo':
-                ddd = str(randint(11, 99))
-                number = f"({ddd}) {randint(2000,5999)}-{randint(1000,9999)}"
-            else:
-                ddd = param
-                number = f"({ddd}) 9{randint(1000,9999)}-{randint(1000,9999)}"
-        else:
-            ddd = str(randint(11, 99))
-            number = f"({ddd}) 9{randint(1000,9999)}-{randint(1000,9999)}"
-        data_list.append(f"'{number}'")
-    return data_list
+        digits = [random.randint(0, 9) for _ in range(9)]
+
+        # Primeiro dígito verificador
+        val = sum((10 - i) * d for i, d in enumerate(digits)) % 11
+        digits.append(0 if val < 2 else 11 - val)
+
+        # Segundo dígito verificador
+        val = sum((11 - i) * d for i, d in enumerate(digits)) % 11
+        digits.append(0 if val < 2 else 11 - val)
+
+        cpf_str = '%s%s%s.%s%s%s.%s%s%s-%s%s' % tuple(digits)
+        results.append(cpf_str)
+    return results
 
 
-def CNPJ(records_to_generate, data_type):
+# ---------------------------------------------------------------------------
+# Documentos — CNPJ
+# ---------------------------------------------------------------------------
+
+def CNPJ(records_to_generate: int, data_type: str) -> list[str]:
     """
-    Gera CNPJs válidos (com dígitos verificadores corretos).
+    Gera CNPJs válidos com dígitos verificadores corretos.
     Formato: XX.XXX.XXX/0001-XX
     """
-    data_list = []
+    _validate_records(records_to_generate)
+    weights1 = (5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+    weights2 = (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+
+    results = []
     for _ in range(records_to_generate):
         base = [random.randint(0, 9) for _ in range(8)] + [0, 0, 0, 1]
 
-        # Primeiro dígito verificador
-        weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
         val = sum(b * w for b, w in zip(base, weights1)) % 11
         base.append(0 if val < 2 else 11 - val)
 
-        # Segundo dígito verificador
-        weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
         val = sum(b * w for b, w in zip(base, weights2)) % 11
         base.append(0 if val < 2 else 11 - val)
 
-        cnpj = '%s%s.%s%s%s.%s%s%s/%s%s%s%s-%s%s' % tuple(base)
-        data_list.append(f"'{cnpj}'")
-    return data_list
+        cnpj_str = "'%s%s.%s%s%s.%s%s%s/%s%s%s%s-%s%s'" % tuple(base)
+        results.append(cnpj_str)
+    return results
 
 
-def CEP(records_to_generate, data_type):
+# ---------------------------------------------------------------------------
+# Nomes
+# ---------------------------------------------------------------------------
+
+def FullName(records_to_generate: int, data_type: str) -> list[str]:
+    """Gera nomes completos a partir do datasource FullNameBR.txt."""
+    _validate_records(records_to_generate)
+    lines = _get_datasource('FullNameBR.txt')
+    return [f"'{random.choice(lines)}'" for _ in range(records_to_generate)]
+
+
+def FirstName(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """Extrai primeiro nome a partir da lista de nomes completos."""
+    _validate_records(records_to_generate)
+    if not value_dict or not value_dict[0]:
+        raise GeneratorError("FirstName requer FullName gerado previamente no value_dict")
+
+    fullnames = value_dict[0]
+    results = []
+    for i in range(records_to_generate):
+        name = fullnames[i].strip("'")
+        parts = name.split()
+        results.append(f"'{parts[0]}'")
+    return results
+
+
+def LastName(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """Extrai sobrenome a partir da lista de nomes completos."""
+    _validate_records(records_to_generate)
+    if not value_dict or not value_dict[0]:
+        raise GeneratorError("LastName requer FullName gerado previamente no value_dict")
+
+    fullnames = value_dict[0]
+    results = []
+    for i in range(records_to_generate):
+        name = fullnames[i].strip("'")
+        parts = name.split()
+        results.append(f"'{parts[-1]}'")
+    return results
+
+
+def UserName(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
     """
-    Gera CEPs aleatórios no formato XXXXX-XXX.
-    USO:
-        CEP       -> CEP totalmente aleatório
-        CEP:SP    -> CEP com faixa de São Paulo (01000-19999)
-    """
-    # Faixas aproximadas por UF (primeiro dígito)
-    uf_ranges = {
-        'SP': (1000, 19999), 'RJ': (20000, 28999), 'ES': (29000, 29999),
-        'MG': (30000, 39999), 'BA': (40000, 48999), 'SE': (49000, 49999),
-        'PE': (50000, 56999), 'AL': (57000, 57999), 'PB': (58000, 58999),
-        'RN': (59000, 59999), 'CE': (60000, 63999), 'PI': (64000, 64999),
-        'MA': (65000, 65999), 'PA': (66000, 68899), 'AP': (68900, 68999),
-        'AM': (69000, 69299), 'RR': (69300, 69399), 'AC': (69900, 69999),
-        'DF': (70000, 72799), 'GO': (72800, 76799), 'TO': (77000, 77999),
-        'MT': (78000, 78899), 'MS': (79000, 79999), 'PR': (80000, 87999),
-        'SC': (88000, 89999), 'RS': (90000, 99999),
-    }
+    Gera username a partir do nome completo (inicial + sobrenome).
 
-    data_list = []
+    Uso:
+        UserName      -> ex: 'jsilva'
+        UserName:Num  -> ex: 'jsilva042871'
+    """
+    _validate_records(records_to_generate)
+    if not value_dict or not value_dict[0]:
+        raise GeneratorError("UserName requer FullName gerado previamente no value_dict")
+
+    add_number = ":" in data_type and "Num" in data_type
+    fullnames = value_dict[0]
+    results = []
+    for i in range(records_to_generate):
+        name = fullnames[i].strip("'")
+        parts = name.split()
+        username = (parts[0][0] + parts[-1]).lower()
+        if add_number:
+            username += str(randint(0, 999999)).rjust(6, "0")
+        results.append(f"'{username}'")
+    return results
+
+
+def Email(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """Gera email a partir do nome completo (nome.sobrenome@example.com)."""
+    _validate_records(records_to_generate)
+    if not value_dict or not value_dict[0]:
+        raise GeneratorError("Email requer FullName gerado previamente no value_dict")
+
+    fullnames = value_dict[0]
+    results = []
+    for i in range(records_to_generate):
+        name = fullnames[i].strip("'")
+        parts = name.split()
+        email = f"{parts[0].lower()}.{parts[-1].lower()}@example.com"
+        results.append(f"'{email}'")
+    return results
+
+
+def InitName(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """Retorna o primeiro caractere do último campo gerado."""
+    _validate_records(records_to_generate)
+    if not value_dict:
+        raise GeneratorError("InitName requer pelo menos um campo gerado previamente")
+
+    last_field = value_dict[-1]
+    results = []
+    for i in range(records_to_generate):
+        char = str(last_field[i])[1]  # pula a aspa inicial
+        results.append(f"'{char}'")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Gênero
+# ---------------------------------------------------------------------------
+
+def Sex(records_to_generate: int, data_type: str) -> list[str]:
+    """Gera valor aleatório de sexo/gênero do datasource."""
+    _validate_records(records_to_generate)
+    lines = _get_datasource('Sex.txt')
+    return [f"'{random.choice(lines)}'" for _ in range(records_to_generate)]
+
+
+# ---------------------------------------------------------------------------
+# Endereço / Localização
+# ---------------------------------------------------------------------------
+
+def Address(records_to_generate: int, data_type: str) -> list[str]:
+    """
+    Gera endereços brasileiros aleatórios.
+
+    Uso:
+        Address      -> ex: 'Rua Santos'
+        Address:Num  -> ex: 'Rua Santos, 127'
+    """
+    _validate_records(records_to_generate)
+    address_lines = _get_datasource('AddressTypeBR.txt')
+    name_lines = _get_datasource('FullNameBR.txt')
+    add_number = ":" in data_type and "Num" in data_type
+
+    results = []
     for _ in range(records_to_generate):
+        place_type = random.choice(address_lines).split(",")[0]
+        chosen_name = random.choice(name_lines)
+        words = chosen_name.split()
+        num_words = random.randint(1, min(2, len(words)))
+        selected = random.sample(words, num_words)
+        line = f"{place_type} {' '.join(selected)}"
+        if add_number:
+            line += f", {randint(0, 999)}"
+        results.append(f"'{line}'")
+    return results
+
+
+def City(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """
+    Gera cidades brasileiras.
+
+    Uso:
+        City     -> cidade aleatória
+        City:SP  -> cidade do estado especificado
+    """
+    _validate_records(records_to_generate)
+
+    if ":" in data_type:
+        uf = data_type.split(":")[1]
+        lines = _search_in_datasource('CityBR.txt', uf)
+    else:
+        lines = _get_datasource('CityBR.txt')
+
+    results = []
+    for _ in range(records_to_generate):
+        line = random.choice(lines)
+        parts = line.split(",")
+        city = parts[2].strip() if len(parts) > 2 else line.strip()
+        results.append(f"'{city}'")
+    return results
+
+
+def StateProvince(records_to_generate: int, data_type: str, value_dict: list) -> list[str]:
+    """
+    Gera estados/províncias brasileiros.
+
+    Uso:
+        StateProvince        -> estado aleatório
+        StateProvince:SP     -> filtra por UF (retorna nome do estado)
+        StateProvince:Find   -> busca estado compatível com a cidade anterior
+    """
+    _validate_records(records_to_generate)
+
+    if ":" in data_type:
+        param = data_type.split(":")[1]
+        if param == "Find":
+            # Busca estado compatível com a última cidade gerada
+            if not value_dict:
+                raise GeneratorError(
+                    "StateProvince:Find requer City gerado previamente"
+                )
+            last_field = value_dict[-1]
+            results = []
+            for i in range(records_to_generate):
+                city_name = str(last_field[i]).replace("'", "")
+                matched = _search_in_datasource('CityBR.txt', city_name)
+                state = matched[0].split(",")[0].strip()
+                results.append(f"'{state}'")
+            return results
+        else:
+            lines = _search_in_datasource('CityBR.txt', param)
+    else:
+        lines = _get_datasource('StateProvinceBR.txt')
+
+    results = []
+    for _ in range(records_to_generate):
+        line = random.choice(lines)
         if ":" in data_type:
-            uf = data_type.split(":")[1].upper()
-            if uf in uf_ranges:
-                prefix = randint(*uf_ranges[uf])
-            else:
-                prefix = randint(1000, 99999)
+            state = line.split(",")[0].strip()
+        else:
+            state = line.strip()
+        results.append(f"'{state}'")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Texto genérico
+# ---------------------------------------------------------------------------
+
+def Varchar(records_to_generate: int, data_type: str) -> list[str]:
+    """
+    Gera strings aleatórias de comprimento fixo.
+
+    Uso:
+        Varchar:N  (ex: Varchar:10)
+    """
+    _validate_records(records_to_generate)
+
+    parts = data_type.split(":")
+    if len(parts) != 2 or not parts[1].isdigit():
+        raise GeneratorError(
+            f"Formato inválido para Varchar: '{data_type}'. "
+            "Esperado: Varchar:N (ex: Varchar:10)"
+        )
+
+    length = int(parts[1])
+    if length <= 0:
+        raise GeneratorError(f"Varchar: comprimento deve ser > 0, recebeu {length}")
+
+    letters = string.ascii_letters
+    return [
+        "'" + ''.join(random.choices(letters, k=length)) + "'"
+        for _ in range(records_to_generate)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Telefone
+# ---------------------------------------------------------------------------
+
+def Phone(records_to_generate: int, data_type: str) -> list[str]:
+    """
+    Gera números de telefone brasileiros.
+
+    Uso:
+        Phone         -> celular com DDD aleatório: (XX) 9XXXX-XXXX
+        Phone:fixo    -> fixo com DDD aleatório: (XX) XXXX-XXXX
+        Phone:XX      -> celular com DDD específico (ex: Phone:11)
+    """
+    _validate_records(records_to_generate)
+
+    results = []
+    if ":" in data_type:
+        param = data_type.split(":")[1]
+        is_fixo = param == "fixo"
+        ddd_fixo = None if is_fixo else param
+    else:
+        is_fixo = False
+        ddd_fixo = None
+
+    for _ in range(records_to_generate):
+        ddd = ddd_fixo or str(randint(11, 99))
+        if is_fixo:
+            number = f"({ddd}) {randint(2000, 5999)}-{randint(1000, 9999)}"
+        else:
+            number = f"({ddd}) 9{randint(1000, 9999)}-{randint(1000, 9999)}"
+        results.append(f"'{number}'")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CEP
+# ---------------------------------------------------------------------------
+
+_UF_CEP_RANGES: dict[str, tuple[int, int]] = {
+    'SP': (1000, 19999), 'RJ': (20000, 28999), 'ES': (29000, 29999),
+    'MG': (30000, 39999), 'BA': (40000, 48999), 'SE': (49000, 49999),
+    'PE': (50000, 56999), 'AL': (57000, 57999), 'PB': (58000, 58999),
+    'RN': (59000, 59999), 'CE': (60000, 63999), 'PI': (64000, 64999),
+    'MA': (65000, 65999), 'PA': (66000, 68899), 'AP': (68900, 68999),
+    'AM': (69000, 69299), 'RR': (69300, 69399), 'AC': (69900, 69999),
+    'DF': (70000, 72799), 'GO': (72800, 76799), 'TO': (77000, 77999),
+    'MT': (78000, 78899), 'MS': (79000, 79999), 'PR': (80000, 87999),
+    'SC': (88000, 89999), 'RS': (90000, 99999),
+}
+
+
+def CEP(records_to_generate: int, data_type: str) -> list[str]:
+    """
+    Gera CEPs brasileiros aleatórios no formato XXXXX-XXX.
+
+    Uso:
+        CEP       -> CEP totalmente aleatório
+        CEP:SP    -> CEP na faixa do estado especificado
+    """
+    _validate_records(records_to_generate)
+
+    uf = None
+    if ":" in data_type:
+        uf = data_type.split(":")[1].upper()
+        if uf not in _UF_CEP_RANGES:
+            raise GeneratorError(
+                f"UF desconhecida para CEP: '{uf}'. "
+                f"Válidas: {', '.join(sorted(_UF_CEP_RANGES.keys()))}"
+            )
+
+    results = []
+    for _ in range(records_to_generate):
+        if uf:
+            prefix = randint(*_UF_CEP_RANGES[uf])
         else:
             prefix = randint(1000, 99999)
-
         suffix = randint(0, 999)
-        cep = f"{prefix:05d}-{suffix:03d}"
-        data_list.append(f"'{cep}'")
-    return data_list
+        results.append(f"'{prefix:05d}-{suffix:03d}'")
+    return results
 
 
-def UUID(records_to_generate, data_type):
-    """
-    Gera UUIDs v4 aleatórios.
-    """
-    data_list = []
-    for _ in range(records_to_generate):
-        data_list.append(f"'{_uuid.uuid4()}'")
-    return data_list
+# ---------------------------------------------------------------------------
+# UUID
+# ---------------------------------------------------------------------------
+
+def UUID(records_to_generate: int, data_type: str) -> list[str]:
+    """Gera UUIDs v4 aleatórios."""
+    _validate_records(records_to_generate)
+    return [f"'{_uuid.uuid4()}'" for _ in range(records_to_generate)]
 
 
-def Boolean(records_to_generate, data_type):
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+
+def Boolean(records_to_generate: int, data_type: str) -> list:
     """
     Gera valores booleanos aleatórios.
-    USO:
+
+    Uso:
         Boolean          -> TRUE/FALSE
         Boolean:int      -> 1/0
-        Boolean:bit      -> 1/0 (alias de int)
+        Boolean:bit      -> 1/0
     """
-    data_list = []
-    for _ in range(records_to_generate):
-        val = random.choice([True, False])
-        if ":" in data_type:
-            param = data_type.split(":")[1].lower()
-            if param in ('int', 'bit'):
-                data_list.append(1 if val else 0)
-            else:
-                data_list.append('TRUE' if val else 'FALSE')
-        else:
-            data_list.append('TRUE' if val else 'FALSE')
-    return data_list
+    _validate_records(records_to_generate)
+
+    use_int = False
+    if ":" in data_type:
+        param = data_type.split(":")[1].lower()
+        use_int = param in ('int', 'bit')
+
+    if use_int:
+        return [random.choice((1, 0)) for _ in range(records_to_generate)]
+    else:
+        return [random.choice(('TRUE', 'FALSE')) for _ in range(records_to_generate)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lebre"
-version = "2.1.0"
+version = "2.2.0"
 description = "A Database Populator — generates random data to fill your project's tables."
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
     "Topic :: Database",
     "Topic :: Software Development :: Testing",
@@ -42,3 +41,13 @@ include = ["generators*", "datasources*"]
 
 [tool.setuptools.package-data]
 datasources = ["*.txt"]
+
+
+[project.optional-dependencies.dev]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Testes end-to-end do CLI via subprocess."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+CLI = [sys.executable, "-m", "cli"]
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def run_cli(*args, cwd=None, input_text=None):
+    """Executa o CLI e retorna (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        [*CLI, *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd or ROOT,
+        input=input_text,
+        timeout=30,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Testes de help e version
+# ---------------------------------------------------------------------------
+
+class TestCLIBasics:
+    def test_help(self):
+        rc, out, _ = run_cli('--help')
+        assert rc == 0
+        assert 'Lebre' in out
+
+    def test_version(self):
+        rc, out, _ = run_cli('--version')
+        assert rc == 0
+        assert '2.2.0' in out
+
+    def test_no_command_shows_help(self):
+        rc, out, _ = run_cli()
+        assert rc == 0
+        assert 'Lebre' in out or 'usage' in out.lower()
+
+    def test_list_types(self):
+        rc, out, _ = run_cli('list-types')
+        assert rc == 0
+        assert 'Serial' in out
+        assert 'CPF' in out
+        assert 'FullName' in out
+
+
+# ---------------------------------------------------------------------------
+# Testes de create-table
+# ---------------------------------------------------------------------------
+
+class TestCreateTable:
+    def test_create_json(self, tmp_path):
+        rc, out, err = run_cli(
+            'create-table',
+            '--name', 'tbl_users',
+            '--fields', 'id,nome,email',
+            '--types', 'Serial,FullName,Email',
+            '--records', '10',
+            '--tables-dir', str(tmp_path),
+        )
+        assert rc == 0
+        assert 'Tabela salva' in out
+
+        # Verifica que o arquivo foi criado e é JSON válido
+        files = list(tmp_path.glob('*.json'))
+        assert len(files) == 1
+        with open(files[0]) as f:
+            data = json.load(f)
+        assert data[0]['TableName'] == 'tbl_users'
+        assert data[0]['RecordsToGenerate'] == 10
+
+    def test_create_toml(self, tmp_path):
+        rc, out, err = run_cli(
+            'create-table',
+            '--name', 'tbl_x',
+            '--fields', 'id,val',
+            '--types', 'Serial,Integer:0:10',
+            '--records', '5',
+            '--tables-dir', str(tmp_path),
+            '--table-format', 'toml',
+        )
+        assert rc == 0
+        files = list(tmp_path.glob('*.toml'))
+        assert len(files) == 1
+
+    def test_fields_types_mismatch(self, tmp_path):
+        rc, out, err = run_cli(
+            'create-table',
+            '--name', 'bad',
+            '--fields', 'a,b,c',
+            '--types', 'Serial,CPF',
+            '--records', '5',
+            '--tables-dir', str(tmp_path),
+        )
+        assert rc == 1
+        assert 'difere' in err or 'número' in err
+
+
+# ---------------------------------------------------------------------------
+# Testes de populate
+# ---------------------------------------------------------------------------
+
+class TestPopulate:
+    @pytest.fixture
+    def table_dir(self, tmp_path):
+        """Cria um diretório com uma tabela de teste."""
+        table = [{
+            "TableName": "tbl_test",
+            "FieldList": "id,cpf,nome,email",
+            "DataType": "Serial,CPF,FullName,Email",
+            "RecordsToGenerate": 10,
+        }]
+        table_file = tmp_path / "00_tbl_test.json"
+        table_file.write_text(json.dumps(table), encoding='utf-8')
+        return tmp_path
+
+    def test_populate_sql_stdout(self, table_dir):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--format', 'sql',
+            '--stdout',
+        )
+        assert rc == 0
+        assert 'INSERT INTO' in out
+        assert 'VALUES' in out
+        # Verifica que tem 10 linhas de valores
+        value_lines = [l for l in out.splitlines() if l.strip().startswith('(')]
+        assert len(value_lines) == 10
+
+    def test_populate_csv_stdout(self, table_dir):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--format', 'csv',
+            '--stdout',
+        )
+        assert rc == 0
+        lines = [l for l in out.strip().splitlines() if l.strip()]
+        assert lines[0] == 'id,cpf,nome,email'  # header
+        assert len(lines) == 11  # header + 10 registros
+
+    def test_populate_json_stdout(self, table_dir):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--format', 'json',
+            '--stdout',
+        )
+        assert rc == 0
+        data = json.loads(out)
+        assert 'tbl_test' in data
+        assert len(data['tbl_test']) == 10
+        # Verifica que cada registro tem os campos corretos
+        for row in data['tbl_test']:
+            assert set(row.keys()) == {'id', 'cpf', 'nome', 'email'}
+
+    def test_populate_to_file(self, table_dir, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--output-dir', str(output_dir),
+            '--format', 'sql',
+        )
+        assert rc == 0
+        assert 'Arquivo gerado' in out
+        files = list(output_dir.glob('*.sql'))
+        assert len(files) == 1
+
+    def test_populate_mysql_dialect(self, table_dir):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--format', 'sql',
+            '--dialect', 'mysql',
+            '--stdout',
+        )
+        assert rc == 0
+        assert '`tbl_test`' in out
+
+    def test_populate_sqlite_dialect(self, table_dir):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(table_dir),
+            '--format', 'sql',
+            '--dialect', 'sqlite',
+            '--stdout',
+        )
+        assert rc == 0
+        assert 'tbl_test' in out
+        # sqlite não usa quotes
+        assert '`' not in out
+        assert '"' not in out.replace('"tbl_test"', '')  # ignora possível no nome
+
+    def test_populate_empty_dir(self, tmp_path):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', str(tmp_path),
+            '--stdout',
+        )
+        assert rc == 1
+        assert 'Nenhuma tabela' in err
+
+    def test_populate_nonexistent_dir(self):
+        rc, out, err = run_cli(
+            'populate',
+            '--tables-dir', '/tmp/naoexiste_xyz_lebre',
+            '--stdout',
+        )
+        assert rc == 1
+        assert 'não encontrado' in err or 'Erro' in err

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Testes dos geradores individuais."""
+import re
+import pytest
+
+from generators.NumericTypes import Serial, Integer
+from generators.TextTypes import (
+    FullName, FirstName, LastName, UserName, Email, CPF, CNPJ,
+    Phone, CEP, UUID, Boolean, Varchar, Sex, Address, City, StateProvince,
+)
+from generators.DateTime import Date, DateTime
+
+
+# ---------------------------------------------------------------------------
+# NumericTypes
+# ---------------------------------------------------------------------------
+
+class TestSerial:
+    def test_default_start(self):
+        result = Serial(5, 'Serial')
+        assert result == [0, 1, 2, 3, 4]
+
+    def test_custom_start(self):
+        result = Serial(3, 'Serial:100')
+        assert result == [100, 101, 102]
+
+    def test_length(self):
+        result = Serial(50, 'Serial')
+        assert len(result) == 50
+
+
+class TestInteger:
+    def test_range(self):
+        result = Integer(100, 'Integer:5:10')
+        assert all(5 <= v <= 10 for v in result)
+
+    def test_length(self):
+        result = Integer(20, 'Integer:0:100')
+        assert len(result) == 20
+
+    def test_single_value_range(self):
+        result = Integer(10, 'Integer:7:7')
+        assert all(v == 7 for v in result)
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — CPF
+# ---------------------------------------------------------------------------
+
+class TestCPF:
+    def _validate_cpf(self, cpf_str):
+        """Valida CPF com algoritmo dos dígitos verificadores."""
+        digits = [int(c) for c in cpf_str if c.isdigit()]
+        if len(digits) != 11:
+            return False
+        # Primeiro dígito verificador
+        val = sum((10 - i) * d for i, d in enumerate(digits[:9])) % 11
+        d1 = 0 if val < 2 else 11 - val
+        if digits[9] != d1:
+            return False
+        # Segundo dígito verificador
+        val = sum((11 - i) * d for i, d in enumerate(digits[:10])) % 11
+        d2 = 0 if val < 2 else 11 - val
+        return digits[10] == d2
+
+    def test_format(self):
+        result = CPF(10, 'CPF')
+        for cpf in result:
+            assert re.match(r'^\d{3}\.\d{3}\.\d{3}-\d{2}$', cpf)
+
+    def test_valid(self):
+        result = CPF(50, 'CPF')
+        for cpf in result:
+            assert self._validate_cpf(cpf), f"CPF inválido: {cpf}"
+
+    def test_length(self):
+        result = CPF(25, 'CPF')
+        assert len(result) == 25
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — CNPJ
+# ---------------------------------------------------------------------------
+
+class TestCNPJ:
+    def _validate_cnpj(self, cnpj_str):
+        """Valida CNPJ com algoritmo dos dígitos verificadores."""
+        digits = [int(c) for c in cnpj_str if c.isdigit()]
+        if len(digits) != 14:
+            return False
+        weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+        val = sum(d * w for d, w in zip(digits[:12], weights1)) % 11
+        d1 = 0 if val < 2 else 11 - val
+        if digits[12] != d1:
+            return False
+        weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+        val = sum(d * w for d, w in zip(digits[:13], weights2)) % 11
+        d2 = 0 if val < 2 else 11 - val
+        return digits[13] == d2
+
+    def test_format(self):
+        result = CNPJ(10, 'CNPJ')
+        for cnpj in result:
+            # Remove aspas SQL
+            cnpj_clean = cnpj.strip("'")
+            assert re.match(r'^\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}$', cnpj_clean)
+
+    def test_valid(self):
+        result = CNPJ(50, 'CNPJ')
+        for cnpj in result:
+            cnpj_clean = cnpj.strip("'")
+            assert self._validate_cnpj(cnpj_clean), f"CNPJ inválido: {cnpj_clean}"
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — Phone
+# ---------------------------------------------------------------------------
+
+class TestPhone:
+    def test_celular_default(self):
+        result = Phone(10, 'Phone')
+        for phone in result:
+            clean = phone.strip("'")
+            assert re.match(r'^\(\d{2}\) 9\d{4}-\d{4}$', clean)
+
+    def test_fixo(self):
+        result = Phone(10, 'Phone:fixo')
+        for phone in result:
+            clean = phone.strip("'")
+            assert re.match(r'^\(\d{2}\) \d{4}-\d{4}$', clean)
+
+    def test_ddd_especifico(self):
+        result = Phone(10, 'Phone:11')
+        for phone in result:
+            clean = phone.strip("'")
+            assert clean.startswith('(11)')
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — CEP
+# ---------------------------------------------------------------------------
+
+class TestCEP:
+    def test_format(self):
+        result = CEP(10, 'CEP')
+        for cep in result:
+            clean = cep.strip("'")
+            assert re.match(r'^\d{5}-\d{3}$', clean)
+
+    def test_uf_filter(self):
+        result = CEP(20, 'CEP:SP')
+        for cep in result:
+            clean = cep.strip("'")
+            prefix = int(clean.split('-')[0])
+            assert 1000 <= prefix <= 19999
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — UUID
+# ---------------------------------------------------------------------------
+
+class TestUUID:
+    def test_format(self):
+        result = UUID(10, 'UUID')
+        for u in result:
+            clean = u.strip("'")
+            assert re.match(
+                r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+                clean
+            )
+
+    def test_unique(self):
+        result = UUID(100, 'UUID')
+        cleaned = [u.strip("'") for u in result]
+        assert len(set(cleaned)) == 100
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — Boolean
+# ---------------------------------------------------------------------------
+
+class TestBoolean:
+    def test_text_mode(self):
+        result = Boolean(50, 'Boolean')
+        assert all(v in ('TRUE', 'FALSE') for v in result)
+
+    def test_int_mode(self):
+        result = Boolean(50, 'Boolean:int')
+        assert all(v in (0, 1) for v in result)
+
+    def test_bit_mode(self):
+        result = Boolean(50, 'Boolean:bit')
+        assert all(v in (0, 1) for v in result)
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — Varchar
+# ---------------------------------------------------------------------------
+
+class TestVarchar:
+    def test_length(self):
+        result = Varchar(10, 'Varchar:8')
+        for v in result:
+            # Remove aspas SQL externas
+            clean = v.strip("'")
+            assert len(clean) == 8
+
+    def test_alpha_only(self):
+        result = Varchar(20, 'Varchar:5')
+        for v in result:
+            clean = v.strip("'")
+            assert clean.isalpha()
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — FullName, FirstName, LastName, UserName, Email
+# ---------------------------------------------------------------------------
+
+class TestNameGenerators:
+    def test_fullname_returns_quoted(self):
+        result = FullName(10, 'FullName')
+        for name in result:
+            assert name.startswith("'") and name.endswith("'")
+            inner = name.strip("'")
+            assert len(inner.split()) >= 2  # pelo menos nome + sobrenome
+
+    def test_firstname_from_fullname(self):
+        fullnames = FullName(10, 'FullName')
+        result = FirstName(10, 'FirstName', [fullnames])
+        for i, fn in enumerate(result):
+            clean = fn.strip("'")
+            full_clean = fullnames[i].strip("'")
+            assert clean == full_clean.split()[0]
+
+    def test_lastname_from_fullname(self):
+        fullnames = FullName(10, 'FullName')
+        result = LastName(10, 'LastName', [fullnames])
+        for i, ln in enumerate(result):
+            clean = ln.strip("'")
+            full_clean = fullnames[i].strip("'")
+            assert clean == full_clean.split()[-1]
+
+    def test_username(self):
+        fullnames = FullName(10, 'FullName')
+        result = UserName(10, 'UserName', [fullnames])
+        for u in result:
+            clean = u.strip("'")
+            assert clean.islower()
+            assert len(clean) >= 2
+
+    def test_username_with_number(self):
+        fullnames = FullName(10, 'FullName')
+        result = UserName(10, 'UserName:Num', [fullnames])
+        for u in result:
+            clean = u.strip("'")
+            assert re.search(r'\d{6}$', clean)
+
+    def test_email_format(self):
+        fullnames = FullName(10, 'FullName')
+        result = Email(10, 'Email', [fullnames])
+        for e in result:
+            clean = e.strip("'")
+            assert '@example.com' in clean
+            assert '.' in clean.split('@')[0]
+
+
+# ---------------------------------------------------------------------------
+# TextTypes — Sex
+# ---------------------------------------------------------------------------
+
+class TestSex:
+    def test_returns_values(self):
+        result = Sex(20, 'Sex')
+        for s in result:
+            clean = s.strip("'")
+            assert len(clean) > 0
+
+
+# ---------------------------------------------------------------------------
+# DateTime
+# ---------------------------------------------------------------------------
+
+class TestDate:
+    def test_default_format(self):
+        result = Date(10, 'Date')
+        for d in result:
+            clean = d.strip("'")
+            assert re.match(r'^\d{2}/\d{2}/\d{4}$', clean)
+
+    def test_custom_range(self):
+        result = Date(10, 'Date:01/01/2020:31/12/2020')
+        for d in result:
+            clean = d.strip("'")
+            year = int(clean.split('/')[2])
+            assert year == 2020
+
+    def test_length(self):
+        result = Date(30, 'Date')
+        assert len(result) == 30
+
+
+class TestDateTime:
+    def test_format(self):
+        result = DateTime(10, 'DateTime')
+        for dt in result:
+            clean = dt.strip("'")
+            # Formato: dd/mm/yyyy HH:MM AM/PM
+            assert re.match(r'^\d{2}/\d{2}/\d{4} \d{2}:\d{2} [AP]M$', clean)

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Testes de validação dos formatos de saída (SQL, CSV, JSON)."""
+
+import csv
+import io
+import json
+import re
+import sys
+import os
+
+import pytest
+
+# Garante que o projeto é importável
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cli import _load_table_file, _generate_values, _populate_sql, _populate_csv, _populate_json
+from generators.DataLoader import DataLoad
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def simple_table(tmp_path):
+    """Cria uma definição de tabela simples."""
+    table = [{
+        "TableName": "tbl_produtos",
+        "FieldList": "id,codigo,nome,ativo",
+        "DataType": "Serial,UUID,Varchar:20,Boolean",
+        "RecordsToGenerate": 25,
+    }]
+    filepath = tmp_path / "produtos.json"
+    filepath.write_text(json.dumps(table), encoding='utf-8')
+    return str(filepath)
+
+
+@pytest.fixture
+def name_table(tmp_path):
+    """Cria tabela com tipos dependentes de FullName."""
+    table = [{
+        "TableName": "tbl_pessoas",
+        "FieldList": "id,nome,sobrenome,usuario,email",
+        "DataType": "Serial,FullName,LastName,UserName,Email",
+        "RecordsToGenerate": 15,
+    }]
+    filepath = tmp_path / "pessoas.json"
+    filepath.write_text(json.dumps(table), encoding='utf-8')
+    return str(filepath)
+
+
+# ---------------------------------------------------------------------------
+# Testes SQL
+# ---------------------------------------------------------------------------
+
+class TestSQLOutput:
+    def test_valid_sql_structure(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output), dialect='postgresql')
+        content = output.read_text()
+
+        assert content.startswith('INSERT INTO')
+        assert 'VALUES' in content
+        assert content.strip().endswith(';')
+
+    def test_postgresql_quoting(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output), dialect='postgresql')
+        content = output.read_text()
+
+        assert '"tbl_produtos"' in content
+        assert '"id"' in content
+
+    def test_mysql_quoting(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output), dialect='mysql')
+        content = output.read_text()
+
+        assert '`tbl_produtos`' in content
+        assert '`id`' in content
+
+    def test_sqlite_no_quoting(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output), dialect='sqlite')
+        content = output.read_text()
+
+        # sqlite: sem aspas
+        first_line = content.splitlines()[1]  # linha com nome da tabela
+        assert '`' not in first_line
+        assert '"' not in first_line
+
+    def test_correct_row_count(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output))
+        content = output.read_text()
+
+        # Conta linhas que começam com tab + (
+        value_lines = [l for l in content.splitlines() if l.strip().startswith('(')]
+        assert len(value_lines) == 25
+
+    def test_last_row_ends_with_semicolon(self, simple_table, tmp_path):
+        output = tmp_path / "out.sql"
+        _populate_sql([simple_table], str(output))
+        content = output.read_text()
+
+        value_lines = [l for l in content.splitlines() if l.strip().startswith('(')]
+        assert value_lines[-1].strip().endswith(';')
+        # Todas as outras terminam com vírgula
+        for line in value_lines[:-1]:
+            assert line.strip().endswith(',')
+
+
+# ---------------------------------------------------------------------------
+# Testes CSV
+# ---------------------------------------------------------------------------
+
+class TestCSVOutput:
+    def test_parseable_csv(self, simple_table, tmp_path):
+        output = tmp_path / "out.csv"
+        _populate_csv([simple_table], str(output))
+        content = output.read_text()
+
+        reader = csv.reader(io.StringIO(content.strip()))
+        rows = list(reader)
+        assert rows[0] == ['id', 'codigo', 'nome', 'ativo']
+        assert len(rows) == 26  # header + 25
+
+    def test_no_sql_quotes_in_csv(self, simple_table, tmp_path):
+        output = tmp_path / "out.csv"
+        _populate_csv([simple_table], str(output))
+        content = output.read_text()
+
+        # Valores não devem ter aspas SQL simples
+        lines = content.strip().splitlines()[1:]  # pula header
+        for line in lines:
+            # Valores UUID e Varchar não devem estar entre aspas simples
+            assert not re.search(r",'[^']*'", line) or "'" not in line
+
+
+# ---------------------------------------------------------------------------
+# Testes JSON
+# ---------------------------------------------------------------------------
+
+class TestJSONOutput:
+    def test_valid_json(self, simple_table, tmp_path):
+        output = tmp_path / "out.json"
+        _populate_json([simple_table], str(output))
+        content = output.read_text()
+
+        data = json.loads(content)
+        assert isinstance(data, dict)
+        assert 'tbl_produtos' in data
+
+    def test_correct_structure(self, simple_table, tmp_path):
+        output = tmp_path / "out.json"
+        _populate_json([simple_table], str(output))
+        data = json.loads(output.read_text())
+
+        rows = data['tbl_produtos']
+        assert len(rows) == 25
+        for row in rows:
+            assert set(row.keys()) == {'id', 'codigo', 'nome', 'ativo'}
+
+    def test_no_sql_quotes_in_json(self, simple_table, tmp_path):
+        output = tmp_path / "out.json"
+        _populate_json([simple_table], str(output))
+        data = json.loads(output.read_text())
+
+        for row in data['tbl_produtos']:
+            for val in row.values():
+                if isinstance(val, str):
+                    assert not (val.startswith("'") and val.endswith("'"))
+
+    def test_serial_is_int(self, simple_table, tmp_path):
+        output = tmp_path / "out.json"
+        _populate_json([simple_table], str(output))
+        data = json.loads(output.read_text())
+
+        for row in data['tbl_produtos']:
+            assert isinstance(row['id'], int)
+
+    def test_name_dependent_fields(self, name_table, tmp_path):
+        output = tmp_path / "out.json"
+        _populate_json([name_table], str(output))
+        data = json.loads(output.read_text())
+
+        for row in data['tbl_pessoas']:
+            assert '@example.com' in row['email']
+            assert len(row['usuario']) >= 2
+            # Sobrenome deve ser parte do nome completo
+            full_parts = row['nome'].split()
+            assert row['sobrenome'] == full_parts[-1]
+
+
+# ---------------------------------------------------------------------------
+# Testes de error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_invalid_json_file(self, tmp_path):
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{ invalid json", encoding='utf-8')
+
+        from cli import TableFileError
+        with pytest.raises(TableFileError, match="Erro de parse"):
+            _load_table_file(str(bad_file))
+
+    def test_missing_fields(self, tmp_path):
+        incomplete = tmp_path / "incomplete.json"
+        incomplete.write_text(json.dumps([{"TableName": "x"}]), encoding='utf-8')
+
+        from cli import TableFileError
+        with pytest.raises(TableFileError, match="obrigatórios ausentes"):
+            _load_table_file(str(incomplete))
+
+    def test_fields_types_count_mismatch(self, tmp_path):
+        bad_table = tmp_path / "mismatch.json"
+        bad_table.write_text(json.dumps([{
+            "TableName": "x",
+            "FieldList": "a,b,c",
+            "DataType": "Serial,CPF",
+            "RecordsToGenerate": 5,
+        }]), encoding='utf-8')
+
+        from cli import TableFileError
+        with pytest.raises(TableFileError, match="Inconsistência"):
+            _load_table_file(str(bad_table))
+
+    def test_nonexistent_file(self):
+        from cli import TableFileError
+        with pytest.raises(TableFileError, match="não encontrado"):
+            _load_table_file("/tmp/arquivo_que_nao_existe_xyz.json")
+
+    def test_unknown_data_type(self, tmp_path):
+        bad_table = tmp_path / "unknown.json"
+        bad_table.write_text(json.dumps([{
+            "TableName": "x",
+            "FieldList": "a",
+            "DataType": "TipoInexistente",
+            "RecordsToGenerate": 5,
+        }]), encoding='utf-8')
+
+        from generators.DataLoader import GeneratorError
+        table_dict = _load_table_file(str(bad_table))
+        with pytest.raises(GeneratorError, match="desconhecido"):
+            _generate_values(table_dict)


### PR DESCRIPTION
## Resumo

Refatoração completa dos geradores e CLI para qualidade de produção, com suite de testes.

Closes #16

## Alterações

### Geradores (generators/)
- **Type hints** em todas as funções públicas
- **Error handling** com exceptions claras (`GeneratorError`, `DatasourceError`)
- **Validação de input** (records > 0, formatos corretos, UFs válidas)
- **DataLoader**: dispatch table ordenada substitui cascata de 20+ if/elif
- **TextTypes**: `random.choices` para Varchar (performance), cache de datasources com validação
- **DateTime**: timestamps calculados uma vez, não re-parseados a cada iteração

### CLI (cli.py)
- **Validação de tabelas**: campos vs tipos count, RecordsToGenerate > 0
- **Exceptions hierárquicas**: `LebreError` → `TableFileError`
- **Error handling**: try/except em todas as operações de I/O e geração
- **Exit codes consistentes**: 0 sucesso, 1 erro com mensagem clara em stderr
- Bump versão para 2.2.0

### Testes (tests/)
- `test_generators.py` — 34 testes de cada gerador individual
  - CPF/CNPJ validados com algoritmo de dígitos verificadores
  - UUID v4 formato e unicidade
  - CEP faixa por UF
- `test_cli.py` — 15 testes end-to-end via subprocess
  - create-table, populate (sql/csv/json), dialetos, erros
- `test_output_formats.py` — 18 testes de formato de saída
  - SQL válido (quoting, separadores)
  - CSV parseável (sem aspas SQL)
  - JSON válido (tipos corretos, sem leak de aspas)
  - Error handling (arquivo inválido, tipo desconhecido)

**Total: 67 testes, todos passando.**

## Como rodar

```bash
uv venv && source .venv/bin/activate
uv pip install -e ".[yaml]" pytest
pytest -v
```